### PR TITLE
Change ndims to behave the same way as for normal variables in matlab.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -329,9 +329,9 @@ classdef DistProp
         end
         function n = ndims(obj)
             if obj.IsArray
-                n = double(obj.NetObject.ndims);
+                n = max(2, double(obj.NetObject.ndims));
             else
-                n = 1;
+                n = 2;
             end
         end
         function n = numel(obj)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1580,9 +1580,6 @@ classdef DistProp
                     u = DistProp(x.GetItem2d(0, 0));
                 else
                     u = DistProp(x);
-                    if ndims(u) == 1
-                        u = reshape(u, size(u));
-                    end
                 end
             else
                 u = DistProp(x);

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -329,9 +329,9 @@ classdef LinProp
         end
         function n = ndims(obj)
             if obj.IsArray
-                n = double(obj.NetObject.ndims);
+                n = max(2, double(obj.NetObject.ndims));
             else
-                n = 1;
+                n = 2;
             end
         end
         function n = numel(obj)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1580,9 +1580,6 @@ classdef LinProp
                     u = LinProp(x.GetItem2d(0, 0));
                 else
                     u = LinProp(x);
-                    if ndims(u) == 1
-                        u = reshape(u, size(u));
-                    end
                 end
             else
                 u = LinProp(x);

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1580,9 +1580,6 @@ classdef MCProp
                     u = MCProp(x.GetItem2d(0, 0));
                 else
                     u = MCProp(x);
-                    if ndims(u) == 1
-                        u = reshape(u, size(u));
-                    end
                 end
             else
                 u = MCProp(x);

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -329,9 +329,9 @@ classdef MCProp
         end
         function n = ndims(obj)
             if obj.IsArray
-                n = double(obj.NetObject.ndims);
+                n = max(2, double(obj.NetObject.ndims));
             else
-                n = 1;
+                n = 2;
             end
         end
         function n = numel(obj)


### PR DESCRIPTION
For scalars and vectors, ndims returned 0. This behavior is not typical for matlab, where vectors, scalars, and even empty variables return 2. This pull request changes ndims to always return at least 2.
This change made a check and call of reshape in Convert2LinProp/Convert2DistProp/... obsolete. As it seems that this call of reshape had no effect anyways, it was removed.