### PR TITLE
Feature parity for subsasgn and subsref

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.8
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 08.06.2021
+% Dion Timmermann PTB - 10.06.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -713,9 +713,6 @@ classdef DistProp
             if ni == 0
                 B = A;
                 return;
-            elseif ni == 1 && isempty(S.subs{1})
-                B = DistProp([]);
-                return;
             end
             
             sizeA = size(A);
@@ -741,16 +738,17 @@ classdef DistProp
                 error('Array indices must be positive integers or logical values.');
             end
             
-            % Replace ':' placeholders 
+            sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
+            % Replace ':' placeholders
             % Note: The last dimension can always be used to address
             % all following dimensions.
             for ii = 1:(ni-1)  % Dimensions except the last one
                 if strcmp(src_subs{ii}, ':')
-                    src_subs{ii} = 1:sizeA(ii);
+                    src_subs{ii} = 1:sizeA_extended(ii);
                 end
             end
             if strcmp(src_subs{ni}, ':') % Special case for last dimension
-                src_subs{ni} = (1:(numel(A)/prod(sizeA(1 : (ni-1)))))';   
+                src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';
             end
             
             % Reshape A if (partial) linear indexing is used.
@@ -763,7 +761,7 @@ classdef DistProp
                     output_shape = [1 numel(src_subs{1})];
                 end
             else
-                sizeAnew = [sizeA(1:ni-1) prod(sizeA(ni:end))];
+                sizeAnew = [sizeA_extended(1:ni-1) prod(sizeA_extended(ni:end))];
                 if numel(sizeAnew) == 1
                     if iscolumn(src_subs{1})
                         sizeAnew = [sizeAnew(1) 1];
@@ -821,7 +819,7 @@ classdef DistProp
             else
                 sizeB = size(B);
                 if numel(sizeB) > 2
-                    lastNonSingletonDimension = find(n>1, 1, 'last');
+                    lastNonSingletonDimension = find(n~=1, 1, 'last');
                     if lastNonSingletonDimension < 2
                         B = reshape(B, sizeB(1:2));
                     else 

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,5 @@
 % Metas.UncLib.Matlab.LinProp V2.4.8
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 04.06.2021
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -713,9 +712,6 @@ classdef LinProp
             if ni == 0
                 B = A;
                 return;
-            elseif ni == 1 && isempty(S.subs{1})
-                B = LinProp([]);
-                return;
             end
             
             sizeA = size(A);
@@ -741,16 +737,17 @@ classdef LinProp
                 error('Array indices must be positive integers or logical values.');
             end
             
+            sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
             % Replace ':' placeholders 
             % Note: The last dimension can always be used to address
             % all following dimensions.
             for ii = 1:(ni-1)  % Dimensions except the last one
                 if strcmp(src_subs{ii}, ':')
-                    src_subs{ii} = 1:sizeA(ii);
+                    src_subs{ii} = 1:sizeA_extended(ii);
                 end
             end
             if strcmp(src_subs{ni}, ':') % Special case for last dimension
-                src_subs{ni} = (1:(numel(A)/prod(sizeA(1 : (ni-1)))))';   
+                src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';   
             end
             
             % Reshape A if (partial) linear indexing is used.
@@ -763,7 +760,7 @@ classdef LinProp
                     output_shape = [1 numel(src_subs{1})];
                 end
             else
-                sizeAnew = [sizeA(1:ni-1) prod(sizeA(ni:end))];
+                sizeAnew = [sizeA_extended(1:ni-1) prod(sizeA_extended(ni:end))];
                 if numel(sizeAnew) == 1
                     if iscolumn(src_subs{1})
                         sizeAnew = [sizeAnew(1) 1];
@@ -821,7 +818,7 @@ classdef LinProp
             else
                 sizeB = size(B);
                 if numel(sizeB) > 2
-                    lastNonSingletonDimension = find(n>1, 1, 'last');
+                    lastNonSingletonDimension = find(n~=1, 1, 'last');
                     if lastNonSingletonDimension < 2
                         B = reshape(B, sizeB(1:2));
                     else 

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -273,9 +273,9 @@ classdef LinProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -283,7 +283,7 @@ classdef LinProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.8
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 08.06.2021
+% Dion Timmermann PTB - 10.06.2021
 %
 % LinProp Const:
 % a = LinProp(value)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -85,7 +85,7 @@ classdef LinProp
                         case 'Metas.UncLib.Core.Ndims.RealNArray<Metas*UncLib*LinProp*UncNumber>'
                             obj.NetObject = varargin{1};
                         case 'Metas.UncLib.Core.Ndims.ComplexNArray<Metas*UncLib*LinProp*UncNumber>'
-                            obj.NetObject = varargin{1};
+                            obj.NetObject = varargin{1};    
                         case 'char'
                             obj.NetObject = LinProp.XmlString2LinProp(varargin{1}).NetObject;
                         otherwise
@@ -249,7 +249,7 @@ classdef LinProp
                     end
                 otherwise
                     error('Wrong number of input arguments')
-            end
+            end 
         end
         function display(obj)
             name = inputname(1);
@@ -268,23 +268,23 @@ classdef LinProp
                     disp(get_value(obj))
                     disp([name,'.standard_unc = '])
                     disp(' ');
-                    disp(get_stdunc(obj))
-                end
+                    disp(get_stdunc(obj))        
+                end    
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' � ' num2str(get_stdunc(real(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' � ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
                         s = [sreal ' + ' simag 'i'];
                     end
-                else
+                else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' � ' num2str(get_stdunc(obj), df) ')'];
-                end
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
+                end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];
                 else
@@ -299,7 +299,7 @@ classdef LinProp
                     disp(' ');
                     disp(s)
                     disp(' ');
-                end
+                end    
             end
         end
         function o = copy(obj)
@@ -442,7 +442,7 @@ classdef LinProp
             %SUBSASGN Subscripted assignment.
             %   A(I) = B assigns the values of B into the elements of A specified by
             %   the subscript vector I.  B must have the same number of elements as I
-            %   or be a scalar.
+            %   or be a scalar. 
             %
             %   A(I,J) = B assigns the values of B into the elements of the rectangular
             %   submatrix of A specified by the subscript vectors I and J.  A colon used as
@@ -451,14 +451,14 @@ classdef LinProp
             %
             %   A(I,J,K,...) = B assigns the values of B to the submatrix of A specified
             %   by the subscript vectors I, J, K, etc. A colon used as a subscript, as in
-            %   A(I,:,K) = B, indicates the entire dimension.
+            %   A(I,:,K) = B, indicates the entire dimension. 
             %
-            %   For both A(I,J) = B and the more general multi-dimensional
+            %   For both A(I,J) = B and the more general multi-dimensional 
             %   A(I,J,K,...) = B, B must be LENGTH(I)-by-LENGTH(J)-by-LENGTH(K)-... , or
             %   be shiftable to that size by adding or removing singleton dimensions, or
             %   contain a scalar, in which case its value is replicated to form a matrix
             %   of that size.
-
+        
             if strcmp('.', {S.type})
                 error('Dot indexing is not supported for variables of this type.');
             elseif strcmp('{}', {S.type})
@@ -466,21 +466,21 @@ classdef LinProp
             elseif length(S) > 1
                 error('Invalid array indexing.');    % This type of error should never appear.
             end
-
+            
             % I describes the index-region of A that values are assigned
             % to. I might be larger than A. In that case, A is extended.
             I = S.subs;
             dimI = numel(I);
-
+            
             % Convert logical indexes to subscripts
             isLogicalIndex = cellfun(@islogical, I);
             I(isLogicalIndex) = cellfun(@find, I(isLogicalIndex), 'UniformOutput', false);
-
+            
             % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
             if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), I(~isLogicalIndex)))
                 error('Array indices must be positive integers or logical values.');
             end
-
+            
             % Special case of null assignment to remove elements
             if isempty(B) && isa(B, 'double')
                 if sum(~strcmp(I, ':')) > 1
@@ -509,7 +509,7 @@ classdef LinProp
                     end
                 end
             end
-
+            
             % Typecasts
             if ~isa(A, 'LinProp')
                 A = LinProp(A);
@@ -522,8 +522,8 @@ classdef LinProp
             elseif ~A.IsComplex && B.IsComplex
                 A = complex(A);
             end
-
-            % Replace ':' placeholders
+            
+            % Replace ':' placeholders 
             % Note: The last dimension can always be used to address
             % all following dimensions.
             sizeA = size(A);
@@ -571,19 +571,19 @@ classdef LinProp
                     end
                 end
                 if strcmp(I{dimI}, ':') % Special case for last dimension
-                    I{dimI} = 1:(numelA/prod(sizeA(1 : (dimI-1))));
+                    I{dimI} = 1:(numelA/prod(sizeA(1 : (dimI-1))));   
                 end
             end
             I_maxIndex = cellfun(@max, I);
-
+            
             % Linear indexing
             if dimI == 1
                 % Linear indexing follows some specific rules
-
+                
                 if ~isscalar(B) && numel(I{1}) ~= numel(B)
                     error('Unable to perform assignment because the left and right sides have a different number of elements.');
                 end
-
+                
                 % Grow vector if necessary
                 if I_maxIndex > numelA
                     if numelA == 0
@@ -599,7 +599,7 @@ classdef LinProp
                         error('Attempt to grow array along ambiguous dimension.');
                     end
                 end
-
+                
                 % Call core library functions to copy values
                 am = LinProp.Convert2UncArray(A);
                 bm = LinProp.Convert2UncArray(B);
@@ -610,25 +610,25 @@ classdef LinProp
                 else
                     am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numel(B)-1)));
                 end
-
+                
                 C = LinProp.Convert2LinProp(am);
                 return;
-
+                
             % Or subscript indexing / partial linear indexing
             else
-
+  
                 if dimI < ndims(A)
                     % partial linear indexing
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
                     end
                 end
-
+                
                 % Check dimensions
                 if ~isscalar(B)
                     sizeI = cellfun(@numel, I);
                     sizeB = size(B);
-
+                    
                     sizeI_reduced = sizeI(sizeI > 1);
                     sizeB_reduced = sizeB(sizeB > 1);
                     if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
@@ -636,9 +636,9 @@ classdef LinProp
                         strjoin(string(sizeI), '-by-'), ...
                         strjoin(string(sizeB), '-by-'));
                     end
-
+                    
                 end
-
+                    
                 % Expand A, if the addressed area is larger
                 if numel(I_maxIndex) > numel(sizeA)
                     sizeA(end+1:numel(I_maxIndex)) = 0; % Expand size vector for A, if nI is larger
@@ -656,14 +656,14 @@ classdef LinProp
                         A = subsasgn(A2, substruct('()', arrayfun(@(x) (1:x), size(A), 'UniformOutput', false)), A);
                     end
                 end
-
+                
                 % Remove trailing singleton dimensions that might have been
                 % addressed. These might actually not exist if the
                 % subscript used was 1.
                 while numel(I) > 2 && numel(I{end}) == 1 && I{end} == 1
                     I(end) = [];
                 end
-
+                
                 % Call core library functions to copy values
                 am = LinProp.Convert2UncArray(A);
                 bm = LinProp.Convert2UncArray(B);
@@ -682,7 +682,7 @@ classdef LinProp
                 return;
 
             end
-
+               
         end
         function B = subsref(A, S)
             %SUBSREF Subscripted reference.
@@ -700,7 +700,7 @@ classdef LinProp
             %
             %   For multi-dimensional arrays, A(I,J,K,...) is the subarray specified by
             %   the subscripts.  The result is LENGTH(I)-by-LENGTH(J)-by-LENGTH(K)-...
-
+            
             if strcmp('.', {S.type})
                 error('Dot indexing is not supported for variables of this type.');
             elseif strcmp('{}', {S.type})
@@ -708,18 +708,18 @@ classdef LinProp
             elseif length(S) > 1
                 error('Invalid array indexing.');    % This type of error should never appear, as it would require multiple round brackets.
             end
-
+            
             ni = numel(S.subs);
             if ni == 0
                 B = A;
                 return;
             end
-
+            
             sizeA = size(A);
             isvectorA = numel(sizeA) == 2 && any(sizeA == 1);
             src_subs = S.subs;
             output_shape = [];
-
+            
             % Convert logical indexes to subscripts
             isLogicalIndex = cellfun(@islogical, src_subs);
             src_subs(isLogicalIndex) = cellfun(@(x) find(x(:)), src_subs(isLogicalIndex), 'UniformOutput', false);
@@ -732,12 +732,12 @@ classdef LinProp
                 output_shape = size(src_subs{1});   % Save shape of output for later.
                 src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
             end
-
+            
             % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
             if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), src_subs(~isLogicalIndex)))
                 error('Array indices must be positive integers or logical values.');
             end
-
+            
             sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
             % Replace ':' placeholders
             % Note: The last dimension can always be used to address
@@ -750,11 +750,11 @@ classdef LinProp
             if strcmp(src_subs{ni}, ':') % Special case for last dimension
                 src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';
             end
-
+            
             % Reshape A if (partial) linear indexing is used.
             if ni == 1 && isvectorA
                 % Special case for shape of output, based on definition of subsref
-                % B has the same shape as A.
+                % B has the same shape as A. 
                 % What is not mentioned in the documentation is that this
                 % only applies if the argument is not ':'.
                 if sizeA(2) > 1 && ~strcmp(S.subs{1}, ':')
@@ -765,7 +765,7 @@ classdef LinProp
                 if numel(sizeAnew) == 1
                     if iscolumn(src_subs{1})
                         sizeAnew = [sizeAnew(1) 1];
-                    else
+                    else 
                         % This is a special case we have to address
                         % later, or we have to use SetItemsNd instead of SetItems1d
                         sizeAnew = [1 sizeAnew(1)];
@@ -822,7 +822,7 @@ classdef LinProp
                     lastNonSingletonDimension = find(n~=1, 1, 'last');
                     if lastNonSingletonDimension < 2
                         B = reshape(B, sizeB(1:2));
-                    else
+                    else 
                         B = reshape(B, sizeB(1:lastNonSingletonDimension));
                     end
                 end
@@ -895,19 +895,19 @@ classdef LinProp
             o = obj.NetObject;
         end
         function d = get_value(obj)
-            h = LinProp.UncHelper();
+            h = LinProp.UncHelper(); 
             d = LinProp.Convert2Double(h.GetValue(obj.NetObject));
         end
         function d = get_stdunc(obj)
-            h = LinProp.UncHelper();
+            h = LinProp.UncHelper(); 
             d = LinProp.Convert2Double(h.GetStdUnc(obj.NetObject));
         end
         function d = get_idof(obj)
-            h = LinProp.UncHelper();
+            h = LinProp.UncHelper(); 
             d = LinProp.Convert2Double(h.GetIDof(obj.NetObject));
         end
         function d = get_fcn_value(obj)
-            h = LinProp.UncHelper();
+            h = LinProp.UncHelper(); 
             d = LinProp.Convert2Double(h.GetFcnValue(obj.NetObject));
         end
         function d = get_coverage_interval(obj, p)
@@ -919,7 +919,7 @@ classdef LinProp
             d = LinProp.Convert2Double(array);
         end
         function d = get_moment(obj, n)
-            h = LinProp.UncHelper();
+            h = LinProp.UncHelper(); 
             d = LinProp.Convert2Double(h.GetMoment(obj.NetObject, int32(n)));
         end
         function c = get_correlation(obj)
@@ -1066,7 +1066,7 @@ classdef LinProp
                     z = LinProp.Convert2LinProp(x.NetObject.Pow(yint));
                 end
             else
-                value = get_value(x);
+                value = get_value(x); 
                 if any(value(:) < 0)
                     x = complex(x);
                 end
@@ -1118,10 +1118,10 @@ classdef LinProp
         function y = conj(x)
             x = complex(x);
             y = LinProp(x.NetObject.Conj());
-        end
+        end        
         function y = abs(x)
             y = LinProp(x.NetObject.Abs());
-        end
+        end       
         function y = angle(x)
             x = complex(x);
             y = LinProp(x.NetObject.Angle());
@@ -1130,21 +1130,21 @@ classdef LinProp
             y = LinProp(x.NetObject.Exp());
         end
         function y = log(x)
-            value = get_value(x);
+            value = get_value(x); 
             if any(value(:) < 0)
                 x = complex(x);
             end
             y = LinProp(x.NetObject.Log());
         end
         function y = log10(x)
-            value = get_value(x);
+            value = get_value(x); 
             if any(value(:) < 0)
                 x = complex(x);
             end
             y = LinProp(x.NetObject.Log10());
         end
         function y = sqrt(x)
-            value = get_value(x);
+            value = get_value(x); 
             if any(value(:) < 0)
                 x = complex(x);
             end
@@ -1672,7 +1672,7 @@ classdef LinProp
             end
             sv = sv.NetObject;
             ev = ev.NetObject;
-
+            
             function c = BoundaryArg(b)
                 if (ischar(b))
                     b = lower(b);
@@ -1736,14 +1736,14 @@ classdef LinProp
                 lu_res = NET.GenericClass('Metas.UncLib.Core.Ndims.RealLuResult', 'Metas.UncLib.LinProp.UncNumber');
                 narray = NET.GenericClass('Metas.UncLib.Core.Ndims.RealNArray', 'Metas.UncLib.LinProp.UncNumber');
                 l = NET.createGeneric('Metas.UncLib.Core.Ndims.LinAlg', {lu_res, narray, 'Metas.UncLib.LinProp.UncNumber'});
-            end
+            end            
         end
         function l = LinAlg2(complex)
             if complex
                 l = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexLinAlg', {'Metas.UncLib.LinProp.UncNumber'});
             else
                 l = NET.createGeneric('Metas.UncLib.Core.Ndims.RealLinAlg', {'Metas.UncLib.LinProp.UncNumber'});
-            end
+            end            
         end
         function l = NumLib(complex)
             if complex
@@ -1753,7 +1753,7 @@ classdef LinProp
             else
                 narray = NET.GenericClass('Metas.UncLib.Core.Ndims.RealNArray', 'Metas.UncLib.LinProp.UncNumber');
                 l = NET.createGeneric('Metas.UncLib.Core.Ndims.NumLib', {narray, 'Metas.UncLib.LinProp.UncNumber'});
-            end
+            end            
         end
         function l = NumLib2(complex)
             if complex
@@ -1765,7 +1765,7 @@ classdef LinProp
         function c = Double2ComplexNumber(d)
             c = NET.createGeneric('Metas.UncLib.Core.Complex', {'Metas.UncLib.Core.Number'});
             c.InitDblReIm(real(d), imag(d));
-        end
+        end        
         function a = Double2Array(d)
             if numel(d) == 0
                 a = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.Core.Number'});
@@ -1812,11 +1812,11 @@ classdef LinProp
                 if x.IsComplex
                     m = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.LinProp.UncNumber'});
                 else
-                    m = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.LinProp.UncNumber'});
+                    m = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.LinProp.UncNumber'});                    
                 end
                 m.Init2d(1, 1);
                 m.SetItem2d(0, 0, x.NetObject);
-            end
+            end 
         end
         function u = Convert2LinProp(x)
             if LinProp.IsArrayNet(x)
@@ -1841,7 +1841,7 @@ classdef LinProp
             for i2 = 1:n2
                 temp_index = mod(floor((0:n1-1)./temp), s(i2)) + 1;
                 m(:,i2) = subs{i2}(temp_index);
-                temp = temp*s(i2);
+                temp = temp*s(i2); 
             end
         end
         function b = IsComplexNet(x)
@@ -1942,5 +1942,5 @@ classdef LinProp
             unc_number.Init(value, sys_inputs.data, sys_sensitivities(:));
             obj = LinProp(unc_number);
         end
-    end
+    end 
 end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.8
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 08.06.2021
+% Dion Timmermann PTB - 10.06.2021
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -713,9 +713,6 @@ classdef MCProp
             if ni == 0
                 B = A;
                 return;
-            elseif ni == 1 && isempty(S.subs{1})
-                B = MCProp([]);
-                return;
             end
             
             sizeA = size(A);
@@ -741,16 +738,17 @@ classdef MCProp
                 error('Array indices must be positive integers or logical values.');
             end
             
-            % Replace ':' placeholders 
+            sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
+            % Replace ':' placeholders
             % Note: The last dimension can always be used to address
             % all following dimensions.
             for ii = 1:(ni-1)  % Dimensions except the last one
                 if strcmp(src_subs{ii}, ':')
-                    src_subs{ii} = 1:sizeA(ii);
+                    src_subs{ii} = 1:sizeA_extended(ii);
                 end
             end
             if strcmp(src_subs{ni}, ':') % Special case for last dimension
-                src_subs{ni} = (1:(numel(A)/prod(sizeA(1 : (ni-1)))))';   
+                src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';
             end
             
             % Reshape A if (partial) linear indexing is used.
@@ -763,7 +761,7 @@ classdef MCProp
                     output_shape = [1 numel(src_subs{1})];
                 end
             else
-                sizeAnew = [sizeA(1:ni-1) prod(sizeA(ni:end))];
+                sizeAnew = [sizeA_extended(1:ni-1) prod(sizeA_extended(ni:end))];
                 if numel(sizeAnew) == 1
                     if iscolumn(src_subs{1})
                         sizeAnew = [sizeAnew(1) 1];
@@ -821,7 +819,7 @@ classdef MCProp
             else
                 sizeB = size(B);
                 if numel(sizeB) > 2
-                    lastNonSingletonDimension = find(n>1, 1, 'last');
+                    lastNonSingletonDimension = find(n~=1, 1, 'last');
                     if lastNonSingletonDimension < 2
                         B = reshape(B, sizeB(1:2));
                     else 


### PR DESCRIPTION
The implementation of subsref from this branch had a bug, where only dimensions which existed could be addressed with `:`. Test cases were added to https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/blob/main/unit_tests_subsref.m . This pull-request fixes the bug. For non-existing dimensions, `:` results in a singleton dimesion, as is default in matlab.
This bugfix also made obsolete the special case `elseif ni == 1 && isempty(S.subs{1})` .

Note: While working on this bugfix, I made a mistake when pulling the changes from upsteam. This caused changes to whitespaces and special chars in LinProp.m, which I only notices a few commits later. I later fixed these changes. If there is a more elegant way, i.e. somehow reverting my commits or copying over the changes to a new branch based of the main branch, I can also try that.