### PR TITLE
Added diff

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1473,6 +1473,76 @@ classdef DistProp
                     error('Too many input arguments')
             end
         end
+        function a = diff(x, varargin)
+            %DIFF Difference and approximate derivative.
+            %   DIFF(X), for a vector X, is [X(2)-X(1)  X(3)-X(2) ... X(n)-X(n-1)].
+            %   DIFF(X), for a matrix X, is the matrix of row differences,
+            %      [X(2:n,:) - X(1:n-1,:)].
+            %   DIFF(X), for an N-D array X, is the difference along the first
+            %      non-singleton dimension of X.
+            %   DIFF(X,N) is the N-th order difference along the first non-singleton 
+            %      dimension (denote it by DIM). If N >= size(X,DIM), DIFF takes 
+            %      successive differences along the next non-singleton dimension.
+            %   DIFF(X,N,DIM) is the Nth difference function along dimension DIM. 
+            %      If N >= size(X,DIM), DIFF returns an empty array.
+            %
+            if nargin > 3
+                error('Too many input arguments.');
+            end
+            if numel(varargin) >= 1
+                if iscell(varargin{1})
+                   error('Undefined function ''diff'' for input arguments of type ''cell''.');
+                end
+                if isempty(varargin{1})
+                    varargin{1} = 1;
+                else
+                    if any(isinf(varargin{1}(:))) || any(isnan(varargin{1}(:)))
+                        error('NaN and Inf not allowed.');
+                    end
+                    if numel(varargin{1}) > 1 || ~isnumeric(varargin{1}) || floor(varargin{1}) ~= varargin{1} || varargin{1} < 0 
+                        error('Difference order N must be a positive integer scalar.');
+                    end
+                end
+                    
+                if varargin{1} > 1
+                    varargin{1} = varargin{1} - 1;
+                    x = diff(x, varargin{:});
+                end
+            end
+            
+            sizeX = size(x);
+            if numel(varargin) >= 2
+                if iscell(varargin{2})
+                   error('Undefined function ''diff'' for input arguments of type ''cell''.');
+                end
+                if numel(varargin{2}) ~= 1
+                    error('Dimension argument must be a positive integer scalar within indexing range.');
+                end
+                if ~isnumeric(varargin{2}) || floor(varargin{2}) ~= varargin{2} || isinf(varargin{2}) || varargin{2} < 0
+                    error('Dimension argument must be a positive integer scalar within indexing range.');
+                end
+                dim = varargin{2};
+            else
+                % find first non-singleton dimension
+                f = [find(sizeX > 1) 1];
+                dim = f(1);
+            end
+            
+            if size(x, dim) <= 1    % Call size instead of using sizeX to appropiatly handle dim>ndims(x)
+                a = DistProp([]);
+                if numel(varargin) >= 2 % If dim was passed as a parameter, return multi-dimensional matrix
+                    sizeX(dim) = 0;
+                    a = reshape(a, sizeX);
+                end
+            else
+                S = cell(1, max(numel(sizeX), dim));
+                S(:) = {':'};
+                S1 = S; S1{dim} = 1:sizeX(dim)-1;
+                S2 = S; S2{dim} = 2:sizeX(dim);
+
+                a = subsref(x, substruct('()', S2)) - subsref(x, substruct('()', S1));
+            end
+        end
         function X = fft(A)
             numlib = DistProp.NumLib2(1);
             A = complex(A);

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1474,6 +1474,18 @@ classdef LinProp
             end
         end
         function a = diff(x, varargin)
+            %DIFF Difference and approximate derivative.
+            %   DIFF(X), for a vector X, is [X(2)-X(1)  X(3)-X(2) ... X(n)-X(n-1)].
+            %   DIFF(X), for a matrix X, is the matrix of row differences,
+            %      [X(2:n,:) - X(1:n-1,:)].
+            %   DIFF(X), for an N-D array X, is the difference along the first
+            %      non-singleton dimension of X.
+            %   DIFF(X,N) is the N-th order difference along the first non-singleton 
+            %      dimension (denote it by DIM). If N >= size(X,DIM), DIFF takes 
+            %      successive differences along the next non-singleton dimension.
+            %   DIFF(X,N,DIM) is the Nth difference function along dimension DIM. 
+            %      If N >= size(X,DIM), DIFF returns an empty array.
+            %
             if nargin > 3
                 error('Too many input arguments.');
             end
@@ -1498,7 +1510,7 @@ classdef LinProp
                 end
             end
             
-            s = size(x);
+            sizeX = size(x);
             if numel(varargin) >= 2
                 if iscell(varargin{2})
                    error('Undefined function ''diff'' for input arguments of type ''cell''.');
@@ -1512,19 +1524,21 @@ classdef LinProp
                 dim = varargin{2};
             else
                 % find first non-singleton dimension
-                f = [find(s > 1) 1];
+                f = [find(sizeX > 1) 1];
                 dim = f(1);
             end
             
-            if dim > numel(s)
-                a = [];
-            elseif s(dim) <= 1
-                a = [];
+            if size(x, dim) <= 1    % Call size instead of using sizeX to appropiatly handle dim>ndims(x)
+                a = LinProp([]);
+                if numel(varargin) >= 2 % If dim was passed as a parameter, return multi-dimensional matrix
+                    sizeX(dim) = 0;
+                    a = reshape(a, sizeX);
+                end
             else
-                S = cell(1, max(numel(s), dim));
+                S = cell(1, max(numel(sizeX), dim));
                 S(:) = {':'};
-                S1 = S; S1{dim} = 1:s(dim)-1;
-                S2 = S; S2{dim} = 2:s(dim);
+                S1 = S; S1{dim} = 1:sizeX(dim)-1;
+                S2 = S; S2{dim} = 2:sizeX(dim);
 
                 a = subsref(x, substruct('()', S2)) - subsref(x, substruct('()', S1));
             end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1475,6 +1475,62 @@ classdef LinProp
                     error('Too many input arguments')
             end
         end
+        function a = diff(x, varargin)
+            if nargin > 3
+                error('Too many input arguments.');
+            end
+            if numel(varargin) >= 1
+                if iscell(varargin{1})
+                   error('Undefined function ''diff'' for input arguments of type ''cell''.');
+                end
+                if isempty(varargin{1})
+                    varargin{1} = 1;
+                else
+                    if any(isinf(varargin{1}(:))) || any(isnan(varargin{1}(:)))
+                        error('NaN and Inf not allowed.');
+                    end
+                    if numel(varargin{1}) > 1 || ~isnumeric(varargin{1}) || floor(varargin{1}) ~= varargin{1} || varargin{1} < 0 
+                        error('Difference order N must be a positive integer scalar.');
+                    end
+                end
+                    
+                if varargin{1} > 1
+                    varargin{1} = varargin{1} - 1;
+                    x = diff(x, varargin{:});
+                end
+            end
+            
+            s = size(x);
+            if numel(varargin) >= 2
+                if iscell(varargin{2})
+                   error('Undefined function ''diff'' for input arguments of type ''cell''.');
+                end
+                if numel(varargin{2}) ~= 1
+                    error('Dimension argument must be a positive integer scalar within indexing range.');
+                end
+                if ~isnumeric(varargin{2}) || floor(varargin{2}) ~= varargin{2} || isinf(varargin{2}) || varargin{2} < 0
+                    error('Dimension argument must be a positive integer scalar within indexing range.');
+                end
+                dim = varargin{2};
+            else
+                % find first non-singleton dimension
+                f = [find(s > 1) 1];
+                dim = f(1);
+            end
+            
+            if dim > numel(s)
+                a = [];
+            elseif s(dim) <= 1
+                a = [];
+            else
+                S = cell(1, max(numel(s), dim));
+                S(:) = {':'};
+                S1 = S; S1{dim} = 1:s(dim)-1;
+                S2 = S; S2{dim} = 2:s(dim);
+
+                a = subsref(x, substruct('()', S2)) - subsref(x, substruct('()', S1));
+            end
+        end
         function X = fft(A)
             numlib = LinProp.NumLib2(1);
             A = complex(A);


### PR DESCRIPTION
I needed the diff() function, i.e. diff(x) = x(2:end)-x(1:end-1), so I implemented it. 

From what I could see, the uncLib does not contain a diff() function. An implemetation using the subtract methods from the uncLib also seemed to not be that helpful, as I first would have to create two copies of the matrix (2:end and 1:end-1). Instead, the implementation presented here only calls subsref and the minus operator and therefore reuses several existing methods.

diff() requires the bugfix to subsref commited in #6 . 