### PR TITLE
Added support for dot indexing and multiple index levels using recursion.

### DIFF
--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -692,7 +692,7 @@ classdef LinProp
             % function would retrun 1. 
             %
             % This class does not support brace indexing. When using dot
-            % indexing on a LinProp matrix, e.g. a = Linprop(1:3); a.Value, 
+            % indexing on a LinProp matrix, e.g. a = LinProp(1:3); a.Value, 
             % we want to return one matrix containing all the values of a.
             % Thus, this function always returns 1.
             %

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -39,7 +39,7 @@
 % a = LinProp(value, standard_unc, idof, id, description)
 
 classdef LinProp
-    properties (Hidden = true)
+    properties
         NetObject
     end
     properties (SetAccess = private)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -715,137 +715,134 @@ classdef LinProp
             %   For multi-dimensional arrays, A(I,J,K,...) is the subarray specified by
             %   the subscripts.  The result is LENGTH(I)-by-LENGTH(J)-by-LENGTH(K)-...
             
-            % Recursively handle multiple levels of indexing
-            if length(S) > 1
-                A = subsref(A, S(1:end-1));
-                S = S(end);
-            end
-            % The rest of this function deals with the last level
-            
-            if strcmp('.', {S.type})
-                B = A.(S.subs);
-                return;
-            elseif strcmp('{}', {S.type})
+            if strcmp('.', S(1).type)
+                B = A.(S(1).subs);
+            elseif strcmp('{}', S(1).type)
                 error('Brace indexing is not supported for variables of this type.');
-            end
-            
-            ni = numel(S.subs);
-            if ni == 0
-                B = A;
-                return;
-            end
-            
-            sizeA = size(A);
-            isvectorA = numel(sizeA) == 2 && any(sizeA == 1);
-            src_subs = S.subs;
-            output_shape = [];
-            
-            % Convert logical indexes to subscripts
-            isLogicalIndex = cellfun(@islogical, src_subs);
-            src_subs(isLogicalIndex) = cellfun(@(x) find(x(:)), src_subs(isLogicalIndex), 'UniformOutput', false);
-
-            % This is a very special case. If linear indexing is used, but
-            % the linear indexes are arranged in form of a matrix, the
-            % output has the shape of the matrix. This does not apply to
-            % logical indexes.
-            if ni == 1 && ~isvector(src_subs{1})
-                output_shape = size(src_subs{1});   % Save shape of output for later.
-                src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
-            end
-            
-            % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
-            if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), src_subs(~isLogicalIndex)))
-                error('Array indices must be positive integers or logical values.');
-            end
-            
-            sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
-            % Replace ':' placeholders
-            % Note: The last dimension can always be used to address
-            % all following dimensions.
-            for ii = 1:(ni-1)  % Dimensions except the last one
-                if strcmp(src_subs{ii}, ':')
-                    src_subs{ii} = 1:sizeA_extended(ii);
-                end
-            end
-            if strcmp(src_subs{ni}, ':') % Special case for last dimension
-                src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';
-            end
-            
-            % Reshape A if (partial) linear indexing is used.
-            if ni == 1 && isvectorA
-                % Special case for shape of output, based on definition of subsref
-                % B has the same shape as A. 
-                % What is not mentioned in the documentation is that this
-                % only applies if the argument is not ':'.
-                if sizeA(2) > 1 && ~strcmp(S.subs{1}, ':')
-                    output_shape = [1 numel(src_subs{1})];
-                end
             else
-                sizeAnew = [sizeA_extended(1:ni-1) prod(sizeA_extended(ni:end))];
-                if numel(sizeAnew) == 1
-                    if iscolumn(src_subs{1})
-                        sizeAnew = [sizeAnew(1) 1];
-                    else 
-                        % This is a special case we have to address
-                        % later, or we have to use SetItemsNd instead of SetItems1d
-                        sizeAnew = [1 sizeAnew(1)];
-                        output_shape  = [1 numel(src_subs{1})];
+
+                ni = numel(S(1).subs);
+                if ni == 0
+                    B = A;
+                else
+
+                    sizeA = size(A);
+                    isvectorA = numel(sizeA) == 2 && any(sizeA == 1);
+                    src_subs = S(1).subs;
+                    output_shape = [];
+
+                    % Convert logical indexes to subscripts
+                    isLogicalIndex = cellfun(@islogical, src_subs);
+                    src_subs(isLogicalIndex) = cellfun(@(x) find(x(:)), src_subs(isLogicalIndex), 'UniformOutput', false);
+
+                    % This is a very special case. If linear indexing is used, but
+                    % the linear indexes are arranged in form of a matrix, the
+                    % output has the shape of the matrix. This does not apply to
+                    % logical indexes.
+                    if ni == 1 && ~isvector(src_subs{1})
+                        output_shape = size(src_subs{1});   % Save shape of output for later.
+                        src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
+                    end
+
+                    % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
+                    if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), src_subs(~isLogicalIndex)))
+                        error('Array indices must be positive integers or logical values.');
+                    end
+
+                    sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
+                    % Replace ':' placeholders
+                    % Note: The last dimension can always be used to address
+                    % all following dimensions.
+                    for ii = 1:(ni-1)  % Dimensions except the last one
+                        if strcmp(src_subs{ii}, ':')
+                            src_subs{ii} = 1:sizeA_extended(ii);
+                        end
+                    end
+                    if strcmp(src_subs{ni}, ':') % Special case for last dimension
+                        src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';
+                    end
+
+                    % Reshape A if (partial) linear indexing is used.
+                    if ni == 1 && isvectorA
+                        % Special case for shape of output, based on definition of subsref
+                        % B has the same shape as A. 
+                        % What is not mentioned in the documentation is that this
+                        % only applies if the argument is not ':'.
+                        if sizeA(2) > 1 && ~strcmp(S(1).subs{1}, ':')
+                            output_shape = [1 numel(src_subs{1})];
+                        end
+                    else
+                        sizeAnew = [sizeA_extended(1:ni-1) prod(sizeA_extended(ni:end))];
+                        if numel(sizeAnew) == 1
+                            if iscolumn(src_subs{1})
+                                sizeAnew = [sizeAnew(1) 1];
+                            else 
+                                % This is a special case we have to address
+                                % later, or we have to use SetItemsNd instead of SetItems1d
+                                sizeAnew = [1 sizeAnew(1)];
+                                output_shape  = [1 numel(src_subs{1})];
+                            end
+                        end
+                        if numel(sizeAnew) ~= numel(sizeA) || any(sizeAnew ~= sizeA)
+                            A = reshape(A, sizeAnew);
+                            sizeA = sizeAnew;
+                            isvectorA = (numel(sizeA) == 2 && any(sizeA == 1));
+                        end
+                    end
+
+                    % Test if indexes are in bounds
+                    if ni == 1 && isvectorA
+                        if any(src_subs{1} > numel(A))
+                            error('Index exceeds the number of array elements (%i).', numel(A));
+                        end
+                    else
+                        too_large = arrayfun(@(m, v) any(v{1} > m), sizeA(1:ni), src_subs);
+                        if any(too_large)
+                            error('Index in position %i exceeds array bounds (must not exceed %i).', find(too_large>0, 1), sizeA(find(too_large>0, 1)));
+                        end
+                    end
+
+                    % Calculate size of output vector
+                    n = cellfun(@(x) numel(x), src_subs);
+                    dest_subs = arrayfun(@(x) 1:x, n, 'UniformOutput', false);
+
+                    % Extract values
+                    am = LinProp.Convert2UncArray(A);
+                    src_index  = LinProp.IndexMatrix(src_subs);
+                    dest_index = LinProp.IndexMatrix(dest_subs);
+                    if A.IsComplex
+                       bm = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.LinProp.UncNumber'});
+                       bm.InitNd(int32(n(:)));
+                    else
+                       bm = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.LinProp.UncNumber'});
+                       bm.InitNd(int32(n(:)));
+                    end
+                    if ni == 1
+                        bm.SetItems1d(int32(dest_index - 1), am.GetItems1d(int32(src_index - 1)));
+                    else
+                        bm.SetItemsNd(int32(dest_index - 1), am.GetItemsNd(int32(src_index - 1)));
+                    end
+                    B = LinProp.Convert2LinProp(bm);
+
+                    % Corect shape of B
+                    if ~isempty(output_shape)
+                        B = reshape(B, output_shape);
+                    else
+                        sizeB = size(B);
+                        if numel(sizeB) > 2
+                            lastNonSingletonDimension = find(n~=1, 1, 'last');
+                            if lastNonSingletonDimension < 2
+                                B = reshape(B, sizeB(1:2));
+                            else 
+                                B = reshape(B, sizeB(1:lastNonSingletonDimension));
+                            end
+                        end
                     end
                 end
-                if numel(sizeAnew) ~= numel(sizeA) || any(sizeAnew ~= sizeA)
-                    A = reshape(A, sizeAnew);
-                    sizeA = sizeAnew;
-                    isvectorA = (numel(sizeA) == 2 && any(sizeA == 1));
-                end
             end
-
-            % Test if indexes are in bounds
-            if ni == 1 && isvectorA
-                if any(src_subs{1} > numel(A))
-                    error('Index exceeds the number of array elements (%i).', numel(A));
-                end
-            else
-                too_large = arrayfun(@(m, v) any(v{1} > m), sizeA(1:ni), src_subs);
-                if any(too_large)
-                    error('Index in position %i exceeds array bounds (must not exceed %i).', find(too_large>0, 1), sizeA(find(too_large>0, 1)));
-                end
-            end
-
-            % Calculate size of output vector
-            n = cellfun(@(x) numel(x), src_subs);
-            dest_subs = arrayfun(@(x) 1:x, n, 'UniformOutput', false);
-
-            % Extract values
-            am = LinProp.Convert2UncArray(A);
-            src_index  = LinProp.IndexMatrix(src_subs);
-            dest_index = LinProp.IndexMatrix(dest_subs);
-            if A.IsComplex
-               bm = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.LinProp.UncNumber'});
-               bm.InitNd(int32(n(:)));
-            else
-               bm = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.LinProp.UncNumber'});
-               bm.InitNd(int32(n(:)));
-            end
-            if ni == 1
-                bm.SetItems1d(int32(dest_index - 1), am.GetItems1d(int32(src_index - 1)));
-            else
-                bm.SetItemsNd(int32(dest_index - 1), am.GetItemsNd(int32(src_index - 1)));
-            end
-            B = LinProp.Convert2LinProp(bm);
-
-            % Corect shape of B
-            if ~isempty(output_shape)
-                B = reshape(B, output_shape);
-            else
-                sizeB = size(B);
-                if numel(sizeB) > 2
-                    lastNonSingletonDimension = find(n~=1, 1, 'last');
-                    if lastNonSingletonDimension < 2
-                        B = reshape(B, sizeB(1:2));
-                    else 
-                        B = reshape(B, sizeB(1:lastNonSingletonDimension));
-                    end
-                end
+            
+            if length(S) > 1
+                B = subsref(B, S(2:end));
             end
         end
         function c = horzcat(a, varargin)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -459,9 +459,9 @@ classdef MCProp
             %   contain a scalar, in which case its value is replicated to form a matrix
             %   of that size.
         
-            if strcmp('.', {S.type})
+            if any(strcmp('.', {S.type}))
                 error('Dot indexing is not supported for variables of this type.');
-            elseif strcmp('{}', {S.type})
+            elseif any(strcmp('{}', {S.type}))
                 error('Brace indexing is not supported for variables of this type.');
             elseif length(S) > 1
                 error('Invalid array indexing.');    % This type of error should never appear.
@@ -684,6 +684,20 @@ classdef MCProp
             end
                
         end
+        function n = numArgumentsFromSubscript(~, ~, ~)
+            % Number of arguments returned by subsref and required by subsasgn. 
+            %
+            % When addressing a = {1, 2, 3} with a{:}, this function would
+            % return 3. When addressing a = {1, 2, 3} with a(:), this
+            % function would retrun 1. 
+            %
+            % This class does not support brace indexing. When using dot
+            % indexing on a MCProp matrix, e.g. a = MCProp(1:3); a.Value, 
+            % we want to return one matrix containing all the values of a.
+            % Thus, this function always returns 1.
+            %
+            n = 1;
+        end
         function B = subsref(A, S)
             %SUBSREF Subscripted reference.
             %   A(I) is an array formed from the elements of A specified by the
@@ -701,131 +715,134 @@ classdef MCProp
             %   For multi-dimensional arrays, A(I,J,K,...) is the subarray specified by
             %   the subscripts.  The result is LENGTH(I)-by-LENGTH(J)-by-LENGTH(K)-...
             
-            if strcmp('.', {S.type})
-                error('Dot indexing is not supported for variables of this type.');
-            elseif strcmp('{}', {S.type})
+            if strcmp('.', S(1).type)
+                B = A.(S(1).subs);
+            elseif strcmp('{}', S(1).type)
                 error('Brace indexing is not supported for variables of this type.');
-            elseif length(S) > 1
-                error('Invalid array indexing.');    % This type of error should never appear, as it would require multiple round brackets.
-            end
-            
-            ni = numel(S.subs);
-            if ni == 0
-                B = A;
-                return;
-            end
-            
-            sizeA = size(A);
-            isvectorA = numel(sizeA) == 2 && any(sizeA == 1);
-            src_subs = S.subs;
-            output_shape = [];
-            
-            % Convert logical indexes to subscripts
-            isLogicalIndex = cellfun(@islogical, src_subs);
-            src_subs(isLogicalIndex) = cellfun(@(x) find(x(:)), src_subs(isLogicalIndex), 'UniformOutput', false);
-
-            % This is a very special case. If linear indexing is used, but
-            % the linear indexes are arranged in form of a matrix, the
-            % output has the shape of the matrix. This does not apply to
-            % logical indexes.
-            if ni == 1 && ~isvector(src_subs{1})
-                output_shape = size(src_subs{1});   % Save shape of output for later.
-                src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
-            end
-            
-            % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
-            if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), src_subs(~isLogicalIndex)))
-                error('Array indices must be positive integers or logical values.');
-            end
-            
-            sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
-            % Replace ':' placeholders
-            % Note: The last dimension can always be used to address
-            % all following dimensions.
-            for ii = 1:(ni-1)  % Dimensions except the last one
-                if strcmp(src_subs{ii}, ':')
-                    src_subs{ii} = 1:sizeA_extended(ii);
-                end
-            end
-            if strcmp(src_subs{ni}, ':') % Special case for last dimension
-                src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';
-            end
-            
-            % Reshape A if (partial) linear indexing is used.
-            if ni == 1 && isvectorA
-                % Special case for shape of output, based on definition of subsref
-                % B has the same shape as A. 
-                % What is not mentioned in the documentation is that this
-                % only applies if the argument is not ':'.
-                if sizeA(2) > 1 && ~strcmp(S.subs{1}, ':')
-                    output_shape = [1 numel(src_subs{1})];
-                end
             else
-                sizeAnew = [sizeA_extended(1:ni-1) prod(sizeA_extended(ni:end))];
-                if numel(sizeAnew) == 1
-                    if iscolumn(src_subs{1})
-                        sizeAnew = [sizeAnew(1) 1];
-                    else 
-                        % This is a special case we have to address
-                        % later, or we have to use SetItemsNd instead of SetItems1d
-                        sizeAnew = [1 sizeAnew(1)];
-                        output_shape  = [1 numel(src_subs{1})];
+
+                ni = numel(S(1).subs);
+                if ni == 0
+                    B = A;
+                else
+
+                    sizeA = size(A);
+                    isvectorA = numel(sizeA) == 2 && any(sizeA == 1);
+                    src_subs = S(1).subs;
+                    output_shape = [];
+
+                    % Convert logical indexes to subscripts
+                    isLogicalIndex = cellfun(@islogical, src_subs);
+                    src_subs(isLogicalIndex) = cellfun(@(x) find(x(:)), src_subs(isLogicalIndex), 'UniformOutput', false);
+
+                    % This is a very special case. If linear indexing is used, but
+                    % the linear indexes are arranged in form of a matrix, the
+                    % output has the shape of the matrix. This does not apply to
+                    % logical indexes.
+                    if ni == 1 && ~isvector(src_subs{1})
+                        output_shape = size(src_subs{1});   % Save shape of output for later.
+                        src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
+                    end
+
+                    % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
+                    if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), src_subs(~isLogicalIndex)))
+                        error('Array indices must be positive integers or logical values.');
+                    end
+
+                    sizeA_extended = [sizeA ones(1, ni-numel(sizeA))];
+                    % Replace ':' placeholders
+                    % Note: The last dimension can always be used to address
+                    % all following dimensions.
+                    for ii = 1:(ni-1)  % Dimensions except the last one
+                        if strcmp(src_subs{ii}, ':')
+                            src_subs{ii} = 1:sizeA_extended(ii);
+                        end
+                    end
+                    if strcmp(src_subs{ni}, ':') % Special case for last dimension
+                        src_subs{ni} = (1:(numel(A)/prod(sizeA_extended(1 : (ni-1)))))';
+                    end
+
+                    % Reshape A if (partial) linear indexing is used.
+                    if ni == 1 && isvectorA
+                        % Special case for shape of output, based on definition of subsref
+                        % B has the same shape as A. 
+                        % What is not mentioned in the documentation is that this
+                        % only applies if the argument is not ':'.
+                        if sizeA(2) > 1 && ~strcmp(S(1).subs{1}, ':')
+                            output_shape = [1 numel(src_subs{1})];
+                        end
+                    else
+                        sizeAnew = [sizeA_extended(1:ni-1) prod(sizeA_extended(ni:end))];
+                        if numel(sizeAnew) == 1
+                            if iscolumn(src_subs{1})
+                                sizeAnew = [sizeAnew(1) 1];
+                            else 
+                                % This is a special case we have to address
+                                % later, or we have to use SetItemsNd instead of SetItems1d
+                                sizeAnew = [1 sizeAnew(1)];
+                                output_shape  = [1 numel(src_subs{1})];
+                            end
+                        end
+                        if numel(sizeAnew) ~= numel(sizeA) || any(sizeAnew ~= sizeA)
+                            A = reshape(A, sizeAnew);
+                            sizeA = sizeAnew;
+                            isvectorA = (numel(sizeA) == 2 && any(sizeA == 1));
+                        end
+                    end
+
+                    % Test if indexes are in bounds
+                    if ni == 1 && isvectorA
+                        if any(src_subs{1} > numel(A))
+                            error('Index exceeds the number of array elements (%i).', numel(A));
+                        end
+                    else
+                        too_large = arrayfun(@(m, v) any(v{1} > m), sizeA(1:ni), src_subs);
+                        if any(too_large)
+                            error('Index in position %i exceeds array bounds (must not exceed %i).', find(too_large>0, 1), sizeA(find(too_large>0, 1)));
+                        end
+                    end
+
+                    % Calculate size of output vector
+                    n = cellfun(@(x) numel(x), src_subs);
+                    dest_subs = arrayfun(@(x) 1:x, n, 'UniformOutput', false);
+
+                    % Extract values
+                    am = MCProp.Convert2UncArray(A);
+                    src_index  = MCProp.IndexMatrix(src_subs);
+                    dest_index = MCProp.IndexMatrix(dest_subs);
+                    if A.IsComplex
+                       bm = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.MCProp.UncNumber'});
+                       bm.InitNd(int32(n(:)));
+                    else
+                       bm = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.MCProp.UncNumber'});
+                       bm.InitNd(int32(n(:)));
+                    end
+                    if ni == 1
+                        bm.SetItems1d(int32(dest_index - 1), am.GetItems1d(int32(src_index - 1)));
+                    else
+                        bm.SetItemsNd(int32(dest_index - 1), am.GetItemsNd(int32(src_index - 1)));
+                    end
+                    B = MCProp.Convert2MCProp(bm);
+
+                    % Corect shape of B
+                    if ~isempty(output_shape)
+                        B = reshape(B, output_shape);
+                    else
+                        sizeB = size(B);
+                        if numel(sizeB) > 2
+                            lastNonSingletonDimension = find(n~=1, 1, 'last');
+                            if lastNonSingletonDimension < 2
+                                B = reshape(B, sizeB(1:2));
+                            else 
+                                B = reshape(B, sizeB(1:lastNonSingletonDimension));
+                            end
+                        end
                     end
                 end
-                if numel(sizeAnew) ~= numel(sizeA) || any(sizeAnew ~= sizeA)
-                    A = reshape(A, sizeAnew);
-                    sizeA = sizeAnew;
-                    isvectorA = (numel(sizeA) == 2 && any(sizeA == 1));
-                end
             end
-
-            % Test if indexes are in bounds
-            if ni == 1 && isvectorA
-                if any(src_subs{1} > numel(A))
-                    error('Index exceeds the number of array elements (%i).', numel(A));
-                end
-            else
-                too_large = arrayfun(@(m, v) any(v{1} > m), sizeA(1:ni), src_subs);
-                if any(too_large)
-                    error('Index in position %i exceeds array bounds (must not exceed %i).', find(too_large>0, 1), sizeA(find(too_large>0, 1)));
-                end
-            end
-
-            % Calculate size of output vector
-            n = cellfun(@(x) numel(x), src_subs);
-            dest_subs = arrayfun(@(x) 1:x, n, 'UniformOutput', false);
-
-            % Extract values
-            am = MCProp.Convert2UncArray(A);
-            src_index  = MCProp.IndexMatrix(src_subs);
-            dest_index = MCProp.IndexMatrix(dest_subs);
-            if A.IsComplex
-               bm = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.MCProp.UncNumber'});
-               bm.InitNd(int32(n(:)));
-            else
-               bm = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.MCProp.UncNumber'});
-               bm.InitNd(int32(n(:)));
-            end
-            if ni == 1
-                bm.SetItems1d(int32(dest_index - 1), am.GetItems1d(int32(src_index - 1)));
-            else
-                bm.SetItemsNd(int32(dest_index - 1), am.GetItemsNd(int32(src_index - 1)));
-            end
-            B = MCProp.Convert2MCProp(bm);
-
-            % Corect shape of B
-            if ~isempty(output_shape)
-                B = reshape(B, output_shape);
-            else
-                sizeB = size(B);
-                if numel(sizeB) > 2
-                    lastNonSingletonDimension = find(n~=1, 1, 'last');
-                    if lastNonSingletonDimension < 2
-                        B = reshape(B, sizeB(1:2));
-                    else 
-                        B = reshape(B, sizeB(1:lastNonSingletonDimension));
-                    end
-                end
+            
+            if length(S) > 1
+                B = subsref(B, S(2:end));
             end
         end
         function c = horzcat(a, varargin)


### PR DESCRIPTION
These changes also make the variable editor behave properly for LinProp variables.

These changes have not yet been tested intensively, i.e. I have not yet created a test script. But simple code like this now works:
```
clear

a = LinProp(5);
a.Value

b = [LinProp(5) LinProp(6) LinProp(7)];
b.Value
b(2:3).Value
```

For now, I have only editied LinProp.m. Once there are no remaining issues, I will copy the changes to DistProp and MCProp.

The most important change was to overload `numArgumentsFromSubscript`. As that function's use is really confusing for me, I added relatively detailed explanation. 

Further minor issues/ToDos:
* I also set NetObject to hidden, so it does not show in the variable editor.
* I am unsure if isArray should really be visible. It is rather an internal property of the variable, than one that is important for normal users.
* It now might also be possible to allow set access for Value and StdUnc, although I am not sure, if that is really useful...