### PR TITLE
Use builtin in subsref

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,4 +1,4 @@
-% Metas.UncLib.Matlab.DistProp V2.4.8
+% Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 28.05.2021
 % Dion Timmermann PTB - 14.06.2021
 %

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.8
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 10.06.2021
+% Dion Timmermann PTB - 14.06.2021
 %
 % DistProp Const:
 % a = DistProp(value)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -716,7 +716,7 @@ classdef DistProp
             %   the subscripts.  The result is LENGTH(I)-by-LENGTH(J)-by-LENGTH(K)-...
             
             if strcmp('.', S(1).type)
-                B = A.(S(1).subs);
+                B = builtin('subsref', A, S);
             elseif strcmp('{}', S(1).type)
                 error('Brace indexing is not supported for variables of this type.');
             else
@@ -839,10 +839,11 @@ classdef DistProp
                         end
                     end
                 end
-            end
-            
-            if length(S) > 1
-                B = subsref(B, S(2:end));
+                
+                % after S(1).type == '()' has been processed
+                if length(S) > 1
+                    B = subsref(B, S(2:end));
+                end
             end
         end
         function c = horzcat(a, varargin)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,4 +1,4 @@
-% Metas.UncLib.Matlab.LinProp V2.4.8
+% Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 28.05.2021
 % Dion Timmermann PTB - 14.06.2021
 %

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.8
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 10.06.2021
+% Dion Timmermann PTB - 14.06.2021
 %
 % LinProp Const:
 % a = LinProp(value)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -716,7 +716,7 @@ classdef LinProp
             %   the subscripts.  The result is LENGTH(I)-by-LENGTH(J)-by-LENGTH(K)-...
             
             if strcmp('.', S(1).type)
-                B = A.(S(1).subs);
+                B = builtin('subsref', A, S);
             elseif strcmp('{}', S(1).type)
                 error('Brace indexing is not supported for variables of this type.');
             else
@@ -839,10 +839,11 @@ classdef LinProp
                         end
                     end
                 end
-            end
-            
-            if length(S) > 1
-                B = subsref(B, S(2:end));
+                
+                % after S(1).type == '()' has been processed
+                if length(S) > 1
+                    B = subsref(B, S(2:end));
+                end
             end
         end
         function c = horzcat(a, varargin)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,4 +1,4 @@
-% Metas.UncLib.Matlab.MCProp V2.4.8
+% Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 28.05.2021
 % Dion Timmermann PTB - 14.06.2021
 %

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -716,7 +716,7 @@ classdef MCProp
             %   the subscripts.  The result is LENGTH(I)-by-LENGTH(J)-by-LENGTH(K)-...
             
             if strcmp('.', S(1).type)
-                B = A.(S(1).subs);
+                B = builtin('subsref', A, S);
             elseif strcmp('{}', S(1).type)
                 error('Brace indexing is not supported for variables of this type.');
             else
@@ -839,10 +839,11 @@ classdef MCProp
                         end
                     end
                 end
-            end
-            
-            if length(S) > 1
-                B = subsref(B, S(2:end));
+                
+                % after S(1).type == '()' has been processed
+                if length(S) > 1
+                    B = subsref(B, S(2:end));
+                end
             end
         end
         function c = horzcat(a, varargin)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.8
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 10.06.2021
+% Dion Timmermann PTB - 14.06.2021
 %
 % MCProp Const:
 % a = MCProp(value)


### PR DESCRIPTION
Instead of calling `B = A.(S(1).subs);` to implement the dot notation in subsref, `B = builtin('subsref', A, S);` is used. Calling builtin is in my opinion better, as we simply rely on the native implementation of subsref for the dot operator. The builtin implementation also allows methods to be called with the dot notation, i.e. 
```
a = LinProp(5, 0.1);
a.get_coverage_interval(0.95)
```
The code passes all tests in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests, except preexisting differences/fails.

Possible one should add some aliases to methods, so statements get shorter, like `a.Coverage(0.95)` similar to `a.Value`, but I would leave that decision up to @wollmich .