### PR TITLE
Added support for more than 2 dimensions for horzcat and vertcat

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 14.06.2021
+% Dion Timmermann PTB - 03.08.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -847,51 +847,63 @@ classdef DistProp
             end
         end
         function c = horzcat(a, varargin)
-            n = nargin - 1;
-            if n == 0
-                c = a;
-            elseif n > 1
-                for i = 1:n
-                    a = [a varargin{i}];
+            
+            catDim = 2;
+            c = a;
+                
+            if numel(varargin) > 0
+                ndimsA = ndims(a);
+                if any(cellfun(@ndims, varargin) ~= ndimsA)
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                c = a;
-            else
-                a = DistProp(a);
-                b = DistProp(varargin{1});
-                if a.IsComplex && ~b.IsComplex
-                    b = complex(b);
+                checkDims = 1:ndimsA;
+                checkDims(catDim) = [];
+                sizeAExceptCatDim = size(a, checkDims);
+                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                if ~a.IsComplex && b.IsComplex
-                    a = complex(a);
+                
+                sizeAInCatDim = size(a, catDim);
+                for ii = 1:numel(varargin)
+                    subs = cell(1, ndimsA);
+                    subs(:) = {':'};
+                    sizeVararginInCatDim = size(varargin{ii}, catDim);
+                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    c = subsasgn(c, substruct('()', subs), varargin{ii});
+                    
+                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
                 end
-                am = DistProp.Convert2UncArray(a);
-                bm = DistProp.Convert2UncArray(b);
-                cm = am.HorzCat(bm);
-                c = DistProp.Convert2DistProp(cm);
+                
             end
         end
         function c = vertcat(a, varargin)
-            n = nargin - 1;
-            if n == 0
-                c = a;
-            elseif n > 1
-                for i = 1:n
-                    a = [a; varargin{i}];
+            
+            catDim = 1;
+            c = a;
+                
+            if numel(varargin) > 0
+                ndimsA = ndims(a);
+                if any(cellfun(@ndims, varargin) ~= ndimsA)
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                c = a;
-            else
-                a = DistProp(a);
-                b = DistProp(varargin{1});
-                if a.IsComplex && ~b.IsComplex
-                    b = complex(b);
+                checkDims = 1:ndimsA;
+                checkDims(catDim) = [];
+                sizeAExceptCatDim = size(a, checkDims);
+                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                if ~a.IsComplex && b.IsComplex
-                    a = complex(a);
+                
+                sizeAInCatDim = size(a, catDim);
+                for ii = 1:numel(varargin)
+                    subs = cell(1, ndimsA);
+                    subs(:) = {':'};
+                    sizeVararginInCatDim = size(varargin{ii}, catDim);
+                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    c = subsasgn(c, substruct('()', subs), varargin{ii});
+                    
+                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
                 end
-                am = DistProp.Convert2UncArray(a);
-                bm = DistProp.Convert2UncArray(b);
-                cm = am.VertCat(bm);
-                c = DistProp.Convert2DistProp(cm);
+                
             end
         end
         function d = get.Value(obj)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -279,9 +279,9 @@ classdef DistProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -289,7 +289,7 @@ classdef DistProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -279,9 +279,9 @@ classdef LinProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -289,7 +289,7 @@ classdef LinProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 14.06.2021
+% Dion Timmermann PTB - 03.08.2021
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -847,51 +847,63 @@ classdef LinProp
             end
         end
         function c = horzcat(a, varargin)
-            n = nargin - 1;
-            if n == 0
-                c = a;
-            elseif n > 1
-                for i = 1:n
-                    a = [a varargin{i}];
+            
+            catDim = 2;
+            c = a;
+                
+            if numel(varargin) > 0
+                ndimsA = ndims(a);
+                if any(cellfun(@ndims, varargin) ~= ndimsA)
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                c = a;
-            else
-                a = LinProp(a);
-                b = LinProp(varargin{1});
-                if a.IsComplex && ~b.IsComplex
-                    b = complex(b);
+                checkDims = 1:ndimsA;
+                checkDims(catDim) = [];
+                sizeAExceptCatDim = size(a, checkDims);
+                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                if ~a.IsComplex && b.IsComplex
-                    a = complex(a);
+                
+                sizeAInCatDim = size(a, catDim);
+                for ii = 1:numel(varargin)
+                    subs = cell(1, ndimsA);
+                    subs(:) = {':'};
+                    sizeVararginInCatDim = size(varargin{ii}, catDim);
+                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    c = subsasgn(c, substruct('()', subs), varargin{ii});
+                    
+                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
                 end
-                am = LinProp.Convert2UncArray(a);
-                bm = LinProp.Convert2UncArray(b);
-                cm = am.HorzCat(bm);
-                c = LinProp.Convert2LinProp(cm);
+                
             end
         end
         function c = vertcat(a, varargin)
-            n = nargin - 1;
-            if n == 0
-                c = a;
-            elseif n > 1
-                for i = 1:n
-                    a = [a; varargin{i}];
+            
+            catDim = 1;
+            c = a;
+                
+            if numel(varargin) > 0
+                ndimsA = ndims(a);
+                if any(cellfun(@ndims, varargin) ~= ndimsA)
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                c = a;
-            else
-                a = LinProp(a);
-                b = LinProp(varargin{1});
-                if a.IsComplex && ~b.IsComplex
-                    b = complex(b);
+                checkDims = 1:ndimsA;
+                checkDims(catDim) = [];
+                sizeAExceptCatDim = size(a, checkDims);
+                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                if ~a.IsComplex && b.IsComplex
-                    a = complex(a);
+                
+                sizeAInCatDim = size(a, catDim);
+                for ii = 1:numel(varargin)
+                    subs = cell(1, ndimsA);
+                    subs(:) = {':'};
+                    sizeVararginInCatDim = size(varargin{ii}, catDim);
+                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    c = subsasgn(c, substruct('()', subs), varargin{ii});
+                    
+                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
                 end
-                am = LinProp.Convert2UncArray(a);
-                bm = LinProp.Convert2UncArray(b);
-                cm = am.VertCat(bm);
-                c = LinProp.Convert2LinProp(cm);
+                
             end
         end
         function d = get.Value(obj)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 28.05.2021
-% Dion Timmermann PTB - 14.06.2021
+% Dion Timmermann PTB - 03.08.2021
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -847,51 +847,63 @@ classdef MCProp
             end
         end
         function c = horzcat(a, varargin)
-            n = nargin - 1;
-            if n == 0
-                c = a;
-            elseif n > 1
-                for i = 1:n
-                    a = [a varargin{i}];
+            
+            catDim = 2;
+            c = a;
+                
+            if numel(varargin) > 0
+                ndimsA = ndims(a);
+                if any(cellfun(@ndims, varargin) ~= ndimsA)
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                c = a;
-            else
-                a = MCProp(a);
-                b = MCProp(varargin{1});
-                if a.IsComplex && ~b.IsComplex
-                    b = complex(b);
+                checkDims = 1:ndimsA;
+                checkDims(catDim) = [];
+                sizeAExceptCatDim = size(a, checkDims);
+                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                if ~a.IsComplex && b.IsComplex
-                    a = complex(a);
+                
+                sizeAInCatDim = size(a, catDim);
+                for ii = 1:numel(varargin)
+                    subs = cell(1, ndimsA);
+                    subs(:) = {':'};
+                    sizeVararginInCatDim = size(varargin{ii}, catDim);
+                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    c = subsasgn(c, substruct('()', subs), varargin{ii});
+                    
+                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
                 end
-                am = MCProp.Convert2UncArray(a);
-                bm = MCProp.Convert2UncArray(b);
-                cm = am.HorzCat(bm);
-                c = MCProp.Convert2MCProp(cm);
+                
             end
         end
         function c = vertcat(a, varargin)
-            n = nargin - 1;
-            if n == 0
-                c = a;
-            elseif n > 1
-                for i = 1:n
-                    a = [a; varargin{i}];
+            
+            catDim = 1;
+            c = a;
+                
+            if numel(varargin) > 0
+                ndimsA = ndims(a);
+                if any(cellfun(@ndims, varargin) ~= ndimsA)
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                c = a;
-            else
-                a = MCProp(a);
-                b = MCProp(varargin{1});
-                if a.IsComplex && ~b.IsComplex
-                    b = complex(b);
+                checkDims = 1:ndimsA;
+                checkDims(catDim) = [];
+                sizeAExceptCatDim = size(a, checkDims);
+                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
+                    error('Dimensions of arrays being concatenated are not consistent.');
                 end
-                if ~a.IsComplex && b.IsComplex
-                    a = complex(a);
+                
+                sizeAInCatDim = size(a, catDim);
+                for ii = 1:numel(varargin)
+                    subs = cell(1, ndimsA);
+                    subs(:) = {':'};
+                    sizeVararginInCatDim = size(varargin{ii}, catDim);
+                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    c = subsasgn(c, substruct('()', subs), varargin{ii});
+                    
+                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
                 end
-                am = MCProp.Convert2UncArray(a);
-                bm = MCProp.Convert2UncArray(b);
-                cm = am.VertCat(bm);
-                c = MCProp.Convert2MCProp(cm);
+                
             end
         end
         function d = get.Value(obj)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -279,9 +279,9 @@ classdef MCProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -289,7 +289,7 @@ classdef MCProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];


### PR DESCRIPTION
This pull request fixes #14 .

The new implemtation of horzcat and vertcat relies on subasgn and does not anymore use am.VertCat(bm) / am.HorzCat(bm). For better performance, it might be a good idea to introduce a special case for 2 dimensions, although the impact should be small when the arrays are large.