### PR TITLE
Make .* multiplication (times) replicate singleton dimensions when necessary.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1117,6 +1117,23 @@ classdef DistProp
             if ~x.IsComplex && y.IsComplex
                 x = complex(x);
             end
+            
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                error('Arrays have incompatible sizes for this operation.');
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            repX = ones(1, dims);
+            repX(doRepX) = sizeY(doRepX);
+            x = repmat(x, repX);
+            
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            repY = ones(1, dims);
+            repY(doRepY) = sizeX(doRepY);
+            y = repmat(y, repY);
+            
             if ~x.IsArray && ~y.IsArray
                 z = DistProp(x.NetObject.Multiply(y.NetObject));
             elseif x.IsArray && ~y.IsArray

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1117,6 +1117,23 @@ classdef LinProp
             if ~x.IsComplex && y.IsComplex
                 x = complex(x);
             end
+            
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                error('Arrays have incompatible sizes for this operation.');
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            repX = ones(1, dims);
+            repX(doRepX) = sizeY(doRepX);
+            x = repmat(x, repX);
+            
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            repY = ones(1, dims);
+            repY(doRepY) = sizeX(doRepY);
+            y = repmat(y, repY);
+            
             if ~x.IsArray && ~y.IsArray
                 z = LinProp(x.NetObject.Multiply(y.NetObject));
             elseif x.IsArray && ~y.IsArray

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1117,6 +1117,23 @@ classdef MCProp
             if ~x.IsComplex && y.IsComplex
                 x = complex(x);
             end
+            
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                error('Arrays have incompatible sizes for this operation.');
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            repX = ones(1, dims);
+            repX(doRepX) = sizeY(doRepX);
+            x = repmat(x, repX);
+            
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            repY = ones(1, dims);
+            repY(doRepY) = sizeX(doRepY);
+            y = repmat(y, repY);
+            
             if ~x.IsArray && ~y.IsArray
                 z = MCProp(x.NetObject.Multiply(y.NetObject));
             elseif x.IsArray && ~y.IsArray


### PR DESCRIPTION
rand(n, 1) .* rand(1, m) now produces a n-by-m result by duplicating singleton dimensions. This is the behaviour of double variables in matlab and removes several failed tests in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests .

This replicates the behaviour with double variables. See tests in: https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/blob/main/tests/test_multiplication.m