### PR TITLE
Added error messages to mtimes that match those for mtimes with doubles in matlab 2021a.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1460,6 +1460,14 @@ classdef DistProp
                 if ~x.IsComplex && y.IsComplex
                     x = complex(x);
                 end
+                
+                dims = max(ndims(x), ndims(y));
+                if dims > 2
+                    error('Arguments must be 2-D, or at least one argument must be scalar. Use TIMES (.*) for elementwise multiplication.');
+                elseif any(size(x, 1:dims) ~= size(y, dims:-1:1))
+                    error('Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches the number of rows in the second matrix. To perform elementwise multiplication, use ''.*''.');
+                end
+                
                 linalg = DistProp.LinAlg(x.IsComplex);
                 xm = DistProp.Convert2UncArray(x);
                 ym = DistProp.Convert2UncArray(y);

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 09.08.2021
+% Dion Timmermann PTB - 10.08.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -1464,7 +1464,7 @@ classdef DistProp
                 dims = max(ndims(x), ndims(y));
                 if dims > 2
                     error('Arguments must be 2-D, or at least one argument must be scalar. Use TIMES (.*) for elementwise multiplication.');
-                elseif any(size(x, 1:dims) ~= size(y, dims:-1:1))
+                elseif size(x, 2) ~= size(y, 1)
                     error('Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches the number of rows in the second matrix. To perform elementwise multiplication, use ''.*''.');
                 end
                 

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1460,6 +1460,14 @@ classdef LinProp
                 if ~x.IsComplex && y.IsComplex
                     x = complex(x);
                 end
+                
+                dims = max(ndims(x), ndims(y));
+                if dims > 2
+                    error('Arguments must be 2-D, or at least one argument must be scalar. Use TIMES (.*) for elementwise multiplication.');
+                elseif any(size(x, 1:dims) ~= size(y, dims:-1:1))
+                    error('Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches the number of rows in the second matrix. To perform elementwise multiplication, use ''.*''.');
+                end
+                
                 linalg = LinProp.LinAlg(x.IsComplex);
                 xm = LinProp.Convert2UncArray(x);
                 ym = LinProp.Convert2UncArray(y);

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 09.08.2021
+% Dion Timmermann PTB - 10.08.2021
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -1464,7 +1464,7 @@ classdef LinProp
                 dims = max(ndims(x), ndims(y));
                 if dims > 2
                     error('Arguments must be 2-D, or at least one argument must be scalar. Use TIMES (.*) for elementwise multiplication.');
-                elseif any(size(x, 1:dims) ~= size(y, dims:-1:1))
+                elseif size(x, 2) ~= size(y, 1)
                     error('Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches the number of rows in the second matrix. To perform elementwise multiplication, use ''.*''.');
                 end
                 

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1460,6 +1460,14 @@ classdef MCProp
                 if ~x.IsComplex && y.IsComplex
                     x = complex(x);
                 end
+                
+                dims = max(ndims(x), ndims(y));
+                if dims > 2
+                    error('Arguments must be 2-D, or at least one argument must be scalar. Use TIMES (.*) for elementwise multiplication.');
+                elseif any(size(x, 1:dims) ~= size(y, dims:-1:1))
+                    error('Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches the number of rows in the second matrix. To perform elementwise multiplication, use ''.*''.');
+                end
+                
                 linalg = MCProp.LinAlg(x.IsComplex);
                 xm = MCProp.Convert2UncArray(x);
                 ym = MCProp.Convert2UncArray(y);

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 09.08.2021
+% Dion Timmermann PTB - 10.08.2021
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -1464,7 +1464,7 @@ classdef MCProp
                 dims = max(ndims(x), ndims(y));
                 if dims > 2
                     error('Arguments must be 2-D, or at least one argument must be scalar. Use TIMES (.*) for elementwise multiplication.');
-                elseif any(size(x, 1:dims) ~= size(y, dims:-1:1))
+                elseif size(x, 2) ~= size(y, 1)
                     error('Incorrect dimensions for matrix multiplication. Check that the number of columns in the first matrix matches the number of rows in the second matrix. To perform elementwise multiplication, use ''.*''.');
                 end
                 


### PR DESCRIPTION
I like these error messages, as they provide hints how to resove the errors. But if you would like to avoid this added complexity, you can also reject this pull-request and I will add an 'Accept' - 'differentErrors' flag to the affected tests in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests . Both solutions are fine with me.