### PR TITLE
Added handling for subscript indexes that are not vectors. (Adds support for repmat(a, ...), where a is an unc matrix.)

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 11.08.2021
+% Dion Timmermann PTB - 12.08.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -798,7 +798,7 @@ classdef DistProp
                     if ni == 1 && ~isvector(src_subs{1})
                         output_shape = size(src_subs{1});   % Save shape of output for later.
                         src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
-                    else
+                    elseif ni > 1
                         % If subscript indexing is used, interpret every
                         % index as a vector. (This is necessary for repmat.)
                         src_subs = cellfun(@(x) x(:), src_subs, 'UniformOutput', false);

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 09.08.2021
+% Dion Timmermann PTB - 11.08.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -798,6 +798,10 @@ classdef DistProp
                     if ni == 1 && ~isvector(src_subs{1})
                         output_shape = size(src_subs{1});   % Save shape of output for later.
                         src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
+                    else
+                        % If subscript indexing is used, interpret every
+                        % index as a vector. (This is necessary for repmat.)
+                        src_subs = cellfun(@(x) x(:), src_subs, 'UniformOutput', false);
                     end
 
                     % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 09.08.2021
+% Dion Timmermann PTB - 11.08.2021
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -798,6 +798,10 @@ classdef LinProp
                     if ni == 1 && ~isvector(src_subs{1})
                         output_shape = size(src_subs{1});   % Save shape of output for later.
                         src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
+                    else
+                        % If subscript indexing is used, interpret every
+                        % index as a vector. (This is necessary for repmat.)
+                        src_subs = cellfun(@(x) x(:), src_subs, 'UniformOutput', false);
                     end
 
                     % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 11.08.2021
+% Dion Timmermann PTB - 12.08.2021
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -798,7 +798,7 @@ classdef LinProp
                     if ni == 1 && ~isvector(src_subs{1})
                         output_shape = size(src_subs{1});   % Save shape of output for later.
                         src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
-                    else
+                    elseif ni > 1
                         % If subscript indexing is used, interpret every
                         % index as a vector. (This is necessary for repmat.)
                         src_subs = cellfun(@(x) x(:), src_subs, 'UniformOutput', false);

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 09.08.2021
+% Dion Timmermann PTB - 11.08.2021
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -798,6 +798,10 @@ classdef MCProp
                     if ni == 1 && ~isvector(src_subs{1})
                         output_shape = size(src_subs{1});   % Save shape of output for later.
                         src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
+                    else
+                        % If subscript indexing is used, interpret every
+                        % index as a vector. (This is necessary for repmat.)
+                        src_subs = cellfun(@(x) x(:), src_subs, 'UniformOutput', false);
                     end
 
                     % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 11.08.2021
+% Dion Timmermann PTB - 12.08.2021
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -798,7 +798,7 @@ classdef MCProp
                     if ni == 1 && ~isvector(src_subs{1})
                         output_shape = size(src_subs{1});   % Save shape of output for later.
                         src_subs{1} = src_subs{1}(:);       % But conform to vector for processing.
-                    else
+                    elseif ni > 1
                         % If subscript indexing is used, interpret every
                         % index as a vector. (This is necessary for repmat.)
                         src_subs = cellfun(@(x) x(:), src_subs, 'UniformOutput', false);


### PR DESCRIPTION
Fixes issue #25 .