### PR TITLE
Added the copy function to some methods, to prevent them from sometimes returing a reference and sometimes a copy / new data.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -779,7 +779,7 @@ classdef DistProp
 
                 ni = numel(S(1).subs);
                 if ni == 0
-                    B = A;
+                    B = copy(A);
                 else
 
                     sizeA = size(A);
@@ -1069,7 +1069,7 @@ classdef DistProp
             n = double(obj.NetObject.memsize);
         end
         function y = uplus(x)
-            y = x;
+            y = copy(x);
         end
         function y = uminus(x)
             y = DistProp(x.NetObject.Negative());
@@ -1211,7 +1211,7 @@ classdef DistProp
         end
         function y = complex(x)
             if x.IsComplex
-                y = x;
+                y = copy(x);
             else
                 if x.IsArray
                     y = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.DistProp.UncNumber'});
@@ -1226,7 +1226,7 @@ classdef DistProp
             if x.IsComplex
                 y = DistProp(x.NetObject.Real());
             else
-                y = x;
+                y = copy(x);
             end
         end
         function y = imag(x)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -779,7 +779,7 @@ classdef LinProp
 
                 ni = numel(S(1).subs);
                 if ni == 0
-                    B = A;
+                    B = copy(A);
                 else
 
                     sizeA = size(A);
@@ -1069,7 +1069,7 @@ classdef LinProp
             n = double(obj.NetObject.memsize);
         end
         function y = uplus(x)
-            y = x;
+            y = copy(x);
         end
         function y = uminus(x)
             y = LinProp(x.NetObject.Negative());
@@ -1211,7 +1211,7 @@ classdef LinProp
         end
         function y = complex(x)
             if x.IsComplex
-                y = x;
+                y = copy(x);
             else
                 if x.IsArray
                     y = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.LinProp.UncNumber'});
@@ -1226,7 +1226,7 @@ classdef LinProp
             if x.IsComplex
                 y = LinProp(x.NetObject.Real());
             else
-                y = x;
+                y = copy(x);
             end
         end
         function y = imag(x)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -779,7 +779,7 @@ classdef MCProp
 
                 ni = numel(S(1).subs);
                 if ni == 0
-                    B = A;
+                    B = copy(A);
                 else
 
                     sizeA = size(A);
@@ -1069,7 +1069,7 @@ classdef MCProp
             n = double(obj.NetObject.memsize);
         end
         function y = uplus(x)
-            y = x;
+            y = copy(x);
         end
         function y = uminus(x)
             y = MCProp(x.NetObject.Negative());
@@ -1211,7 +1211,7 @@ classdef MCProp
         end
         function y = complex(x)
             if x.IsComplex
-                y = x;
+                y = copy(x);
             else
                 if x.IsArray
                     y = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.MCProp.UncNumber'});
@@ -1226,7 +1226,7 @@ classdef MCProp
             if x.IsComplex
                 y = MCProp(x.NetObject.Real());
             else
-                y = x;
+                y = copy(x);
             end
         end
         function y = imag(x)


### PR DESCRIPTION
These changes ensure that all regular methods (but not the constructor) always return a copy of the data they were passsed, and not sometimes a copy and sometimes a reference.
These changes fix the side-effects that were observable in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/blob/main/tests/test_side_effects.m. 

These changes are related to #22, but do not resolve the fundamental difference between scalars and matricies regarding the assignment operations `b=a;`, `b = [a]` and the typecasting with `b=LinProp(a)`.