### PR TITLE
Unwrap

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 12.08.2021
+% Dion Timmermann PTB - 02.09.2021
 %
 % DistProp Const:
 % a = DistProp(value)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1244,6 +1244,9 @@ classdef DistProp
             x = complex(x);
             y = DistProp(x.NetObject.Angle());
         end
+        function q = unwrap(p, varargin)
+            q = p + unwrap(double(p), varargin{:}) - double(p);
+        end
         function y = exp(x)
             y = DistProp(x.NetObject.Exp());
         end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 12.08.2021
+% Dion Timmermann PTB - 02.09.2021
 %
 % LinProp Const:
 % a = LinProp(value)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1244,6 +1244,9 @@ classdef LinProp
             x = complex(x);
             y = LinProp(x.NetObject.Angle());
         end
+        function q = unwrap(p, varargin)
+            q = p + unwrap(double(p), varargin{:}) - double(p);
+        end
         function y = exp(x)
             y = LinProp(x.NetObject.Exp());
         end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1244,6 +1244,9 @@ classdef MCProp
             x = complex(x);
             y = MCProp(x.NetObject.Angle());
         end
+        function q = unwrap(p, varargin)
+            q = p + unwrap(double(p), varargin{:}) - double(p);
+        end
         function y = exp(x)
             y = MCProp(x.NetObject.Exp());
         end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 12.08.2021
+% Dion Timmermann PTB - 02.09.2021
 %
 % MCProp Const:
 % a = MCProp(value)


### PR DESCRIPTION
Performs the matlab unwrap function on the nominal value. (I was not able to correctly call the UnwrapPhase() function from the UncLib, but also prefer this approach as it ensures compatibility with the regular unwrap function from matlab.)

If you do not want to add this function to the UncLib, I can also add it to our library. We only need it for extrapolating data and plotting.