### PR TITLE
Added support for array creation functions.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 12.08.2021
+% Dion Timmermann PTB - 03.09.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -1846,6 +1846,32 @@ classdef DistProp
             end
             v = t.BinaryDeserializeFromByteArray(bin.data(:));
             obj = DistProp(v);
+        end
+        % Support for array creation functions.
+        % See: https://www.mathworks.com/help/releases/R2021a/matlab/matlab_oop/class-support-for-array-creation-functions.html
+        function x = zeros(varargin)
+            x = DistProp(zeros(varargin{:}));
+        end
+        function x = ones(varargin)
+            x = DistProp(ones(varargin{:}));
+        end
+        function x = eye(varargin)
+            x = DistProp(eye(varargin{:}));
+        end
+        function x = nan(varargin)
+            x = DistProp(nan(varargin{:}));
+        end
+        function x = inf(varargin)
+            x = DistProp(inf(varargin{:}));
+        end
+        function x = rand(varargin)
+            x = DistProp(rand(varargin{:}));
+        end
+        function x = randi(varargin)
+            x = DistProp(randi(varargin{:}));
+        end
+        function x = randn(varargin)
+            x = DistProp(randn(varargin{:}));
         end
     end
     methods(Static = true, Access = private)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 12.08.2021
+% Dion Timmermann PTB - 03.09.2021
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -1846,6 +1846,32 @@ classdef LinProp
             end
             v = t.BinaryDeserializeFromByteArray(bin.data(:));
             obj = LinProp(v);
+        end
+        % Support for array creation functions.
+        % See: https://www.mathworks.com/help/releases/R2021a/matlab/matlab_oop/class-support-for-array-creation-functions.html
+        function x = zeros(varargin)
+            x = LinProp(zeros(varargin{:}));
+        end
+        function x = ones(varargin)
+            x = LinProp(ones(varargin{:}));
+        end
+        function x = eye(varargin)
+            x = LinProp(eye(varargin{:}));
+        end
+        function x = nan(varargin)
+            x = LinProp(nan(varargin{:}));
+        end
+        function x = inf(varargin)
+            x = LinProp(inf(varargin{:}));
+        end
+        function x = rand(varargin)
+            x = LinProp(rand(varargin{:}));
+        end
+        function x = randi(varargin)
+            x = LinProp(randi(varargin{:}));
+        end
+        function x = randn(varargin)
+            x = LinProp(randn(varargin{:}));
         end
     end
     methods(Static = true, Access = private)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 12.08.2021
+% Dion Timmermann PTB - 03.09.2021
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -1846,6 +1846,32 @@ classdef MCProp
             end
             v = t.BinaryDeserializeFromByteArray(bin.data(:));
             obj = MCProp(v);
+        end
+        % Support for array creation functions.
+        % See: https://www.mathworks.com/help/releases/R2021a/matlab/matlab_oop/class-support-for-array-creation-functions.html
+        function x = zeros(varargin)
+            x = MCProp(zeros(varargin{:}));
+        end
+        function x = ones(varargin)
+            x = MCProp(ones(varargin{:}));
+        end
+        function x = eye(varargin)
+            x = MCProp(eye(varargin{:}));
+        end
+        function x = nan(varargin)
+            x = MCProp(nan(varargin{:}));
+        end
+        function x = inf(varargin)
+            x = MCProp(inf(varargin{:}));
+        end
+        function x = rand(varargin)
+            x = MCProp(rand(varargin{:}));
+        end
+        function x = randi(varargin)
+            x = MCProp(randi(varargin{:}));
+        end
+        function x = randn(varargin)
+            x = MCProp(randn(varargin{:}));
         end
     end
     methods(Static = true, Access = private)


### PR DESCRIPTION
See: https://www.mathworks.com/help/releases/R2021a/matlab/matlab_oop/class-support-for-array-creation-functions.html

Support for array creation functions is very helpfull, if one writes code that is intended to work with different types of data.
The recent changes in the matlab wrapper made it possible to write code that works with unc variables and normal numerical variables. However, initializing new variables is still complicated.

Our old code often looked like this:
```
function out = doSomething(in)
    if isa(in, 'LinProp') || isa(in, 'DistProp') || isa(in, 'MCProp')
        eval(['unc=@' class(in) ';']);
        unc_metas=true;
    else
        unc_metas=false;
    end

    % Later

    if unc_metas
        out=unc(zeros(...));
    else
        out=zeros(...);
    end    

    % populate some values in out based on in.
```
This could possibly be simplified to the following:
```
function out = doSomething(in)
    castOperator = str2func(class(in));
    
    out=castOperator(zeros(...));

    % populate some values in out based on in.
```
But we still have to construct a function from a string and the code might behave unexpectedly without failing, if `in` has an unknown datatype.

The changes in this patch would allow the following code:
```
function out = doSomething(in)
    out=zeros(..., class(in));

    % populate some values in out based on in.
```

Support is added for the functions zeros, ones, eye, nan, inf, rand, randi, and randn.

The functions zeros and ones could also be implemented using repmat, which is a bit faster, but I am not sure about unintended side effects.
```
function x = zeros(varargin)
    x = repmat(LinProp(0), varargin{:});
end
```