### PR TITLE
Fix subsasgn with empty indices

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 16.09.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -279,9 +279,9 @@ classdef DistProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -289,7 +289,7 @@ classdef DistProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];
@@ -1966,12 +1966,12 @@ classdef DistProp
             c.InitDblReIm(real(d), imag(d));
         end        
         function a = Double2Array(d)
-            s = size(d);
-            s = int32(s(:));
             if numel(d) == 0
                 a = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.Core.Number'});
-                a.InitNd(s);
+                a.Init2d(0, 0);
             else
+                s = size(d);
+                s = int32(s(:));
                 d2 = d(:);
                 if ~isreal(d)
                     a = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.Core.Number'});

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 16.09.2021
+% Dion Timmermann PTB - 17.09.2021
 %
 % DistProp Const:
 % a = DistProp(value)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -701,6 +701,15 @@ classdef DistProp
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
                     end
+                else
+                    % Ignore empty and singleton dimensions that have been
+                    % indexed but do not exist anyways.
+                    I_issingleton = cellfun(@(x) all(x == 1), I);
+                    I_lastRelevant = [find(not(I_isempty | I_issingleton), 1, 'last') 2];
+                    I_lastRelevant = I_lastRelevant(1);
+                    I = I(1:min(dimI, max(numel(sizeA), I_lastRelevant)));
+                    dimI = numel(I);
+                    I_maxIndex = I_maxIndex(1:dimI);
                 end
 
                 % Check dimensions

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 03.09.2021
+% Dion Timmermann PTB - 16.09.2021
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -630,16 +630,39 @@ classdef DistProp
                     I{dimI} = 1:(numelA/prod(sizeA(1 : (dimI-1))));   
                 end
             end
-            I_maxIndex = cellfun(@(x) double(max(x)), I);
+            
+            I_isempty = cellfun(@isempty, I);
+            I_maxIndex = zeros(size(I));
+            I_maxIndex(~I_isempty) = cellfun(@(x) double(max(x)), I(~I_isempty));
+            
+            if any(I_isempty) && numelA == 0
+                if numel(B) <= 1
+                    s = I_maxIndex;
+                    if numel(s) < 2
+                        if ~isempty(B)
+                            s = [s zeros(1,2-numel(s))];
+                        else
+                            s = [ones(1,2-numel(s)) s];
+                        end
+                    else
+                        lastNonSingletonDimension = find(s~=1, 1, 'last');
+                        s = s(1:max(2, lastNonSingletonDimension));
+                    end
+                    C = reshape(DistProp([]), s);
+                    return;
+                else 
+                    error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
+                end
+            end
             
             % Linear indexing
             if dimI == 1
                 % Linear indexing follows some specific rules
-                
+
                 if ~isscalar(B) && numel(I{1}) ~= numel(B)
                     error('Unable to perform assignment because the left and right sides have a different number of elements.');
                 end
-                
+
                 % Grow vector if necessary
                 if I_maxIndex > numelA
                     if numelA == 0
@@ -655,7 +678,7 @@ classdef DistProp
                         error('Attempt to grow array along ambiguous dimension.');
                     end
                 end
-                
+
                 % Call core library functions to copy values
                 am = DistProp.Convert2UncArray(A);
                 bm = DistProp.Convert2UncArray(B);
@@ -666,25 +689,25 @@ classdef DistProp
                 else
                     am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numel(B)-1)));
                 end
-                
+
                 C = DistProp.Convert2DistProp(am);
                 return;
-                
+
             % Or subscript indexing / partial linear indexing
             else
-  
+
                 if dimI < ndims(A)
                     % partial linear indexing
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
                     end
                 end
-                
+
                 % Check dimensions
                 if ~isscalar(B)
                     sizeI = cellfun(@numel, I);
                     sizeB = size(B);
-                    
+
                     sizeI_reduced = sizeI(sizeI > 1);
                     sizeB_reduced = sizeB(sizeB > 1);
                     if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
@@ -692,9 +715,9 @@ classdef DistProp
                         strjoin(string(sizeI), '-by-'), ...
                         strjoin(string(sizeB), '-by-'));
                     end
-                    
+
                 end
-                    
+
                 % Expand A, if the addressed area is larger
                 if numel(I_maxIndex) > numel(sizeA)
                     sizeA(end+1:numel(I_maxIndex)) = 0; % Expand size vector for A, if nI is larger
@@ -712,14 +735,14 @@ classdef DistProp
                         A = subsasgn(A2, substruct('()', arrayfun(@(x) (1:x), size(A), 'UniformOutput', false)), A);
                     end
                 end
-                
+
                 % Remove trailing singleton dimensions that might have been
                 % addressed. These might actually not exist if the
                 % subscript used was 1.
                 while numel(I) > 2 && numel(I{end}) == 1 && I{end} == 1
                     I(end) = [];
                 end
-                
+
                 % Call core library functions to copy values
                 am = DistProp.Convert2UncArray(A);
                 bm = DistProp.Convert2UncArray(B);
@@ -738,7 +761,6 @@ classdef DistProp
                 return;
 
             end
-               
         end
         function n = numArgumentsFromSubscript(~, ~, ~)
             % Number of arguments returned by subsref and required by subsasgn. 

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 16.09.2021
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -279,9 +279,9 @@ classdef LinProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -289,7 +289,7 @@ classdef LinProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];
@@ -1966,12 +1966,12 @@ classdef LinProp
             c.InitDblReIm(real(d), imag(d));
         end        
         function a = Double2Array(d)
-            s = size(d);
-            s = int32(s(:));
             if numel(d) == 0
                 a = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.Core.Number'});
-                a.InitNd(s);
+                a.Init2d(0, 0);
             else
+                s = size(d);
+                s = int32(s(:));
                 d2 = d(:);
                 if ~isreal(d)
                     a = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.Core.Number'});

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 03.09.2021
+% Dion Timmermann PTB - 16.09.2021
 %
 % LinProp Const:
 % a = LinProp(value)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -630,115 +630,138 @@ classdef LinProp
                     I{dimI} = 1:(numelA/prod(sizeA(1 : (dimI-1))));   
                 end
             end
-            I_maxIndex = cellfun(@(x) double(max(x)), I);
             
-            % Linear indexing
-            if dimI == 1
-                % Linear indexing follows some specific rules
-                
-                if ~isscalar(B) && numel(I{1}) ~= numel(B)
-                    error('Unable to perform assignment because the left and right sides have a different number of elements.');
-                end
-                
-                % Grow vector if necessary
-                if I_maxIndex > numelA
-                    if numelA == 0
-                        A = LinProp(zeros(1, I_maxIndex));
-                        if B.IsComplex
-                            A = complex(A);
+            I_isempty = cellfun(@isempty, I);
+            I_maxIndex = zeros(size(I));
+            I_maxIndex(~I_isempty) = cellfun(@(x) double(max(x)), I(~I_isempty));
+            
+            if any(I_isempty)
+                if numel(B) <= 1
+                    s = I_maxIndex;
+                    if numel(s) < 2
+                        if ~isempty(B)
+                            s = [s zeros(1,2-numel(s))];
+                        else
+                            s = [ones(1,2-numel(s)) s];
                         end
-                    elseif isrow(A)
-                        A = [A, LinProp(zeros(1, I_maxIndex-numelA))];
-                    elseif iscolumn(A)
-                        A = [A; LinProp(zeros(I_maxIndex-numelA, 1))];
                     else
-                        error('Attempt to grow array along ambiguous dimension.');
+                        lastNonSingletonDimension = find(s~=1, 1, 'last');
+                        s = s(1:max(2, lastNonSingletonDimension));
                     end
+                    C = reshape(LinProp([]), s);
+                    return;
+                else 
+                    error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                 end
-                
-                % Call core library functions to copy values
-                am = LinProp.Convert2UncArray(A);
-                bm = LinProp.Convert2UncArray(B);
-                dest_index = LinProp.IndexMatrix(I);
-
-                if isscalar(B)
-                    am.SetSameItem1d(int32(dest_index - 1), bm.GetItem1d(0));
-                else
-                    am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numel(B)-1)));
-                end
-                
-                C = LinProp.Convert2LinProp(am);
-                return;
-                
-            % Or subscript indexing / partial linear indexing
             else
-  
-                if dimI < ndims(A)
-                    % partial linear indexing
-                    if max(I{end}) > prod(sizeA(dimI:end))
-                        error('Attempt to grow array along ambiguous dimension.');
+            
+                % Linear indexing
+                if dimI == 1
+                    % Linear indexing follows some specific rules
+
+                    if ~isscalar(B) && numel(I{1}) ~= numel(B)
+                        error('Unable to perform assignment because the left and right sides have a different number of elements.');
                     end
-                end
-                
-                % Check dimensions
-                if ~isscalar(B)
-                    sizeI = cellfun(@numel, I);
-                    sizeB = size(B);
-                    
-                    sizeI_reduced = sizeI(sizeI > 1);
-                    sizeB_reduced = sizeB(sizeB > 1);
-                    if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
-                        error('Unable to perform assignment because the size of the left side is %s and the size of the right side is %s.', ...
-                        strjoin(string(sizeI), '-by-'), ...
-                        strjoin(string(sizeB), '-by-'));
+
+                    % Grow vector if necessary
+                    if I_maxIndex > numelA
+                        if numelA == 0
+                            A = LinProp(zeros(1, I_maxIndex));
+                            if B.IsComplex
+                                A = complex(A);
+                            end
+                        elseif isrow(A)
+                            A = [A, LinProp(zeros(1, I_maxIndex-numelA))];
+                        elseif iscolumn(A)
+                            A = [A; LinProp(zeros(I_maxIndex-numelA, 1))];
+                        else
+                            error('Attempt to grow array along ambiguous dimension.');
+                        end
                     end
-                    
-                end
-                    
-                % Expand A, if the addressed area is larger
-                if numel(I_maxIndex) > numel(sizeA)
-                    sizeA(end+1:numel(I_maxIndex)) = 0; % Expand size vector for A, if nI is larger
-                end
-                sA_nI = [sizeA(1 : (dimI-1)), prod(sizeA(dimI:end))]; % size of A, when using the same number of dimensions as nI;
-                if any(I_maxIndex > sA_nI)
-                    A2 = LinProp(zeros(max(I_maxIndex, sA_nI)));
-                    if B.IsComplex
-                        A2 = complex(A2);
-                    end
-                    if numel(A) == 0
-                        A = A2;
+
+                    % Call core library functions to copy values
+                    am = LinProp.Convert2UncArray(A);
+                    bm = LinProp.Convert2UncArray(B);
+                    dest_index = LinProp.IndexMatrix(I);
+
+                    if isscalar(B)
+                        am.SetSameItem1d(int32(dest_index - 1), bm.GetItem1d(0));
                     else
-                        % Copy over existing values from A to A2...
-                        A = subsasgn(A2, substruct('()', arrayfun(@(x) (1:x), size(A), 'UniformOutput', false)), A);
+                        am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numel(B)-1)));
                     end
-                end
-                
-                % Remove trailing singleton dimensions that might have been
-                % addressed. These might actually not exist if the
-                % subscript used was 1.
-                while numel(I) > 2 && numel(I{end}) == 1 && I{end} == 1
-                    I(end) = [];
-                end
-                
-                % Call core library functions to copy values
-                am = LinProp.Convert2UncArray(A);
-                bm = LinProp.Convert2UncArray(B);
-                dest_index = LinProp.IndexMatrix(I);
 
-                if isscalar(B)
-                    am.SetSameItemNd(int32(dest_index - 1), bm.GetItem1d(0));
+                    C = LinProp.Convert2LinProp(am);
+                    return;
+
+                % Or subscript indexing / partial linear indexing
                 else
-                    src_subs = arrayfun(@(x) 1:x, size(B), 'UniformOutput', false);
-                    src_index  = LinProp.IndexMatrix(src_subs);
 
-                    am.SetItemsNd(int32(dest_index - 1), bm.GetItemsNd(int32(src_index - 1)));
+                    if dimI < ndims(A)
+                        % partial linear indexing
+                        if max(I{end}) > prod(sizeA(dimI:end))
+                            error('Attempt to grow array along ambiguous dimension.');
+                        end
+                    end
+
+                    % Check dimensions
+                    if ~isscalar(B)
+                        sizeI = cellfun(@numel, I);
+                        sizeB = size(B);
+
+                        sizeI_reduced = sizeI(sizeI > 1);
+                        sizeB_reduced = sizeB(sizeB > 1);
+                        if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
+                            error('Unable to perform assignment because the size of the left side is %s and the size of the right side is %s.', ...
+                            strjoin(string(sizeI), '-by-'), ...
+                            strjoin(string(sizeB), '-by-'));
+                        end
+
+                    end
+
+                    % Expand A, if the addressed area is larger
+                    if numel(I_maxIndex) > numel(sizeA)
+                        sizeA(end+1:numel(I_maxIndex)) = 0; % Expand size vector for A, if nI is larger
+                    end
+                    sA_nI = [sizeA(1 : (dimI-1)), prod(sizeA(dimI:end))]; % size of A, when using the same number of dimensions as nI;
+                    if any(I_maxIndex > sA_nI)
+                        A2 = LinProp(zeros(max(I_maxIndex, sA_nI)));
+                        if B.IsComplex
+                            A2 = complex(A2);
+                        end
+                        if numel(A) == 0
+                            A = A2;
+                        else
+                            % Copy over existing values from A to A2...
+                            A = subsasgn(A2, substruct('()', arrayfun(@(x) (1:x), size(A), 'UniformOutput', false)), A);
+                        end
+                    end
+
+                    % Remove trailing singleton dimensions that might have been
+                    % addressed. These might actually not exist if the
+                    % subscript used was 1.
+                    while numel(I) > 2 && numel(I{end}) == 1 && I{end} == 1
+                        I(end) = [];
+                    end
+
+                    % Call core library functions to copy values
+                    am = LinProp.Convert2UncArray(A);
+                    bm = LinProp.Convert2UncArray(B);
+                    dest_index = LinProp.IndexMatrix(I);
+
+                    if isscalar(B)
+                        am.SetSameItemNd(int32(dest_index - 1), bm.GetItem1d(0));
+                    else
+                        src_subs = arrayfun(@(x) 1:x, size(B), 'UniformOutput', false);
+                        src_index  = LinProp.IndexMatrix(src_subs);
+
+                        am.SetItemsNd(int32(dest_index - 1), bm.GetItemsNd(int32(src_index - 1)));
+                    end
+
+                    C = LinProp.Convert2LinProp(am);
+                    return;
+
                 end
-
-                C = LinProp.Convert2LinProp(am);
-                return;
-
             end
-               
         end
         function n = numArgumentsFromSubscript(~, ~, ~)
             % Number of arguments returned by subsref and required by subsasgn. 

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 16.09.2021
+% Dion Timmermann PTB - 17.09.2021
 %
 % LinProp Const:
 % a = LinProp(value)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -701,6 +701,15 @@ classdef LinProp
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
                     end
+                else
+                    % Ignore empty and singleton dimensions that have been
+                    % indexed but do not exist anyways.
+                    I_issingleton = cellfun(@(x) all(x == 1), I);
+                    I_lastRelevant = [find(not(I_isempty | I_issingleton), 1, 'last') 2];
+                    I_lastRelevant = I_lastRelevant(1);
+                    I = I(1:min(dimI, max(numel(sizeA), I_lastRelevant)));
+                    dimI = numel(I);
+                    I_maxIndex = I_maxIndex(1:dimI);
                 end
 
                 % Check dimensions

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 16.09.2021
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -279,9 +279,9 @@ classdef MCProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -289,7 +289,7 @@ classdef MCProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];
@@ -1966,12 +1966,12 @@ classdef MCProp
             c.InitDblReIm(real(d), imag(d));
         end        
         function a = Double2Array(d)
-            s = size(d);
-            s = int32(s(:));
             if numel(d) == 0
                 a = NET.createGeneric('Metas.UncLib.Core.Ndims.RealNArray', {'Metas.UncLib.Core.Number'});
-                a.InitNd(s);
+                a.Init2d(0, 0);
             else
+                s = size(d);
+                s = int32(s(:));
                 d2 = d(:);
                 if ~isreal(d)
                     a = NET.createGeneric('Metas.UncLib.Core.Ndims.ComplexNArray', {'Metas.UncLib.Core.Number'});

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -701,6 +701,15 @@ classdef MCProp
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
                     end
+                else
+                    % Ignore empty and singleton dimensions that have been
+                    % indexed but do not exist anyways.
+                    I_issingleton = cellfun(@(x) all(x == 1), I);
+                    I_lastRelevant = [find(not(I_isempty | I_issingleton), 1, 'last') 2];
+                    I_lastRelevant = I_lastRelevant(1);
+                    I = I(1:min(dimI, max(numel(sizeA), I_lastRelevant)));
+                    dimI = numel(I);
+                    I_maxIndex = I_maxIndex(1:dimI);
                 end
 
                 % Check dimensions

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.4.9
 % Michael Wollensack METAS - 05.08.2021
-% Dion Timmermann PTB - 16.09.2021
+% Dion Timmermann PTB - 17.09.2021
 %
 % MCProp Const:
 % a = MCProp(value)


### PR DESCRIPTION
This pull-request fixes #33 . 

There are some tests in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/blob/main/tests/test_subsasgn.m that currently fail. Two are are related to this issue:
```
compare_a_dbl_unc(1, rand(1, 1), 'a([], 2, [], 1) = b;');
compare_a_dbl_unc(1, rand(1, 1), 'a([], 3, [], 1) = b;');
```
In both tests, the array has to be expanded. For this `LinProp(zeros(0, 2, 0, 1))` and `LinProp(zeros(0, 3, 0, 1))` are called by `subsasgn`. The constructors currently always a 0-by-0 vaiable instead of one of correct size (see the new #35). I would suggest to fix the behaviour of the constructor instead of adding a special case to subsasgn. Fixing #35 should allow these two tests to pass. If that is not the case, the changes in this pull-request at least prevent the error being thrown.