### PR TITLE
'close all' also closes unc_budget windows.

### DIFF
--- a/@LinProp/unc_budget.m
+++ b/@LinProp/unc_budget.m
@@ -46,3 +46,14 @@ f.Size.Height = 480;
 f.Controls.Add(c);
 f.Show();
 f.Activate();
+
+% Create a hidden figure and add a callback that is executed on close all.
+% Close the form window when the hidden window is closed by close all.
+fig  = figure('visible','off');
+fig.UserData = 'Invisible Figure to catch ''close all'' and trigger closing of the unc_budget window.';
+fig.CloseRequestFcn = {@closeRequest, f};
+end
+
+function closeRequest(~, ~, f)
+     f.Close();
+end

--- a/@LinProp/unc_budget.m
+++ b/@LinProp/unc_budget.m
@@ -48,9 +48,9 @@ f.Show();
 f.Activate();
 
 % Create a hidden figure and add a callback that is executed on close all.
-% Close the form window when the hidden window is closed by close all.
+% Close the form window when the hidden figure is closed by close all.
 fig  = figure('visible','off');
-fig.UserData = 'Invisible Figure to catch ''close all'' and trigger closing of the unc_budget window.';
+fig.UserData = 'Invisible figure to catch ''close all'' and trigger closing of the unc_budget window.';
 fig.CloseRequestFcn = {@closeRequest, f};
 end
 


### PR DESCRIPTION
unc_budget creates a invisible figure window. Once that invisible figure is closed (by `close all`), the unc_budget window is also closed.