### PR TITLE
Prevented the hidden figure from interfering with plot commands.

### DIFF
--- a/@LinProp/unc_budget.m
+++ b/@LinProp/unc_budget.m
@@ -49,9 +49,11 @@ f.Activate();
 
 % Create a hidden figure and add a callback that is executed on close all.
 % Close the form window when the hidden figure is closed by close all.
+last_current_figure = gcf;
 fig  = figure('visible','off');
 fig.UserData = 'Invisible figure to catch ''close all'' and trigger closing of the unc_budget window.';
 fig.CloseRequestFcn = {@closeRequest, f};
+set(0, 'CurrentFigure', last_current_figure);
 end
 
 function closeRequest(~, ~, f)

--- a/@LinProp/unc_budget.m
+++ b/@LinProp/unc_budget.m
@@ -56,6 +56,8 @@ fig.CloseRequestFcn = {@closeRequest, f};
 set(0, 'CurrentFigure', last_current_figure);
 end
 
-function closeRequest(~, ~, f)
-     f.Close();
+function closeRequest(fig, ~, form)
+% Closes both the Windows.Form and the hidden matlab figure
+     form.Close();
+     delete(fig);
 end

--- a/@LinProp/unc_budget.m
+++ b/@LinProp/unc_budget.m
@@ -1,5 +1,5 @@
 % LinProp Uncertainty Budget
-% Michael Wollensack METAS - 08.08.2017
+% Michael Wollensack METAS - 20.09.2021
 
 function unc_budget(x, varargin)
 
@@ -49,8 +49,8 @@ f.Activate();
 
 % Create a hidden figure and add a callback that is executed on close all.
 % Close the form window when the hidden figure is closed by close all.
-last_current_figure = gcf;
-fig  = figure('visible','off');
+last_current_figure = get(0, 'CurrentFigure');
+fig = figure('visible','off');
 fig.UserData = 'Invisible figure to catch ''close all'' and trigger closing of the unc_budget window.';
 fig.CloseRequestFcn = {@closeRequest, f};
 set(0, 'CurrentFigure', last_current_figure);
@@ -58,6 +58,6 @@ end
 
 function closeRequest(fig, ~, form)
 % Closes both the Windows.Form and the hidden matlab figure
-     form.Close();
-     delete(fig);
+    form.Close();
+    delete(fig);
 end


### PR DESCRIPTION
The following code did not work as expected, as the plot command plotted into the hidden figure. With this patch it works, as the 'currentFigure' is (re)set properly.
```
unc_budget(LinProp(1, 2))
plot(1:2)
```

The `closeRequest` callback also did not close the hidden figure. That was also fixed.
