### PR TITLE
plus, minus, and divide now replicate singleton dimensions

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.0
 % Michael Wollensack METAS - 17.09.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 24.02.2022
 %
 % DistProp Const:
 % a = DistProp(value)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1211,6 +1211,27 @@ classdef DistProp
             elseif ~x.IsArray && y.IsArray
                 z = DistProp(y.NetObject.RDivide(x.NetObject));
             else
+                
+                dims = max(ndims(x), ndims(y));
+                sizeX = size(x, 1:dims);
+                sizeY = size(y, 1:dims);
+                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                    error('Arrays have incompatible sizes for this operation.');
+                end
+                doRepX = sizeX ~= sizeY & sizeX == 1;
+                if any(doRepX)
+                    repX = ones(1, dims);
+                    repX(doRepX) = sizeY(doRepX);
+                    x = repmat(x, repX);
+                end
+
+                doRepY = sizeY ~= sizeX & sizeY == 1;
+                if any(doRepY)
+                    repY = ones(1, dims);
+                    repY(doRepY) = sizeX(doRepY);
+                    y = repmat(y, repY);
+                end
+                
                 z = DistProp(x.NetObject.Divide(y.NetObject));
             end
         end

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1127,6 +1127,7 @@ classdef DistProp
                 elseif ~x.IsArray && y.IsArray
                     z = DistProp(y.NetObject.RAdd(x.NetObject));
                 else
+                    [x, y] = DistProp.replicateSingletonDimensions(x, y);
                     z = DistProp(x.NetObject.Add(y.NetObject));
                 end
             end
@@ -1150,6 +1151,7 @@ classdef DistProp
                 elseif ~x.IsArray && y.IsArray
                     z = DistProp(y.NetObject.RSubtract(x.NetObject));
                 else
+                    [x, y] = DistProp.replicateSingletonDimensions(x, y);
                     z = DistProp(x.NetObject.Subtract(y.NetObject));
                 end
             end
@@ -1171,27 +1173,7 @@ classdef DistProp
             elseif ~x.IsArray && y.IsArray
                 z = DistProp(y.NetObject.RMultiply(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = DistProp.replicateSingletonDimensions(x, y);
                 z = DistProp(x.NetObject.Multiply(y.NetObject));
             end
         end
@@ -1211,27 +1193,7 @@ classdef DistProp
             elseif ~x.IsArray && y.IsArray
                 z = DistProp(y.NetObject.RDivide(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = DistProp.replicateSingletonDimensions(x, y);
                 z = DistProp(x.NetObject.Divide(y.NetObject));
             end
         end
@@ -1946,6 +1908,27 @@ classdef DistProp
         end
     end
     methods(Static = true, Access = private)
+        function [x, y] = replicateSingletonDimensions(x, y)
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                throwAsCaller(MException('MATLAB:sizeDimensionsMustMatch', 'Arrays have incompatible sizes for this operation.'));
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            if any(doRepX)
+                repX = ones(1, dims);
+                repX(doRepX) = sizeY(doRepX);
+                x = repmat(x, repX);
+            end
+
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            if any(doRepY)
+                repY = ones(1, dims);
+                repY(doRepY) = sizeX(doRepY);
+                y = repmat(y, repY);
+            end
+        end
         function h = UncHelper()
             h = NET.createGeneric('Metas.UncLib.Core.Unc.GenericUnc', {'Metas.UncLib.DistProp.UncList', 'Metas.UncLib.DistProp.UncNumber'});
         end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1127,6 +1127,7 @@ classdef LinProp
                 elseif ~x.IsArray && y.IsArray
                     z = LinProp(y.NetObject.RAdd(x.NetObject));
                 else
+                    [x, y] = LinProp.replicateSingletonDimensions(x, y);
                     z = LinProp(x.NetObject.Add(y.NetObject));
                 end
             end
@@ -1150,6 +1151,7 @@ classdef LinProp
                 elseif ~x.IsArray && y.IsArray
                     z = LinProp(y.NetObject.RSubtract(x.NetObject));
                 else
+                    [x, y] = LinProp.replicateSingletonDimensions(x, y);
                     z = LinProp(x.NetObject.Subtract(y.NetObject));
                 end
             end
@@ -1171,27 +1173,7 @@ classdef LinProp
             elseif ~x.IsArray && y.IsArray
                 z = LinProp(y.NetObject.RMultiply(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = LinProp.replicateSingletonDimensions(x, y);
                 z = LinProp(x.NetObject.Multiply(y.NetObject));
             end
         end
@@ -1211,27 +1193,7 @@ classdef LinProp
             elseif ~x.IsArray && y.IsArray
                 z = LinProp(y.NetObject.RDivide(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = LinProp.replicateSingletonDimensions(x, y);
                 z = LinProp(x.NetObject.Divide(y.NetObject));
             end
         end
@@ -1946,6 +1908,27 @@ classdef LinProp
         end
     end
     methods(Static = true, Access = private)
+        function [x, y] = replicateSingletonDimensions(x, y)
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                throwAsCaller(MException('MATLAB:sizeDimensionsMustMatch', 'Arrays have incompatible sizes for this operation.'));
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            if any(doRepX)
+                repX = ones(1, dims);
+                repX(doRepX) = sizeY(doRepX);
+                x = repmat(x, repX);
+            end
+
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            if any(doRepY)
+                repY = ones(1, dims);
+                repY(doRepY) = sizeX(doRepY);
+                y = repmat(y, repY);
+            end
+        end
         function h = UncHelper()
             h = NET.createGeneric('Metas.UncLib.Core.Unc.GenericUnc', {'Metas.UncLib.LinProp.UncList', 'Metas.UncLib.LinProp.UncNumber'});
         end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1211,6 +1211,27 @@ classdef LinProp
             elseif ~x.IsArray && y.IsArray
                 z = LinProp(y.NetObject.RDivide(x.NetObject));
             else
+                
+                dims = max(ndims(x), ndims(y));
+                sizeX = size(x, 1:dims);
+                sizeY = size(y, 1:dims);
+                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                    error('Arrays have incompatible sizes for this operation.');
+                end
+                doRepX = sizeX ~= sizeY & sizeX == 1;
+                if any(doRepX)
+                    repX = ones(1, dims);
+                    repX(doRepX) = sizeY(doRepX);
+                    x = repmat(x, repX);
+                end
+
+                doRepY = sizeY ~= sizeX & sizeY == 1;
+                if any(doRepY)
+                    repY = ones(1, dims);
+                    repY(doRepY) = sizeX(doRepY);
+                    y = repmat(y, repY);
+                end
+                
                 z = LinProp(x.NetObject.Divide(y.NetObject));
             end
         end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.0
 % Michael Wollensack METAS - 17.09.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 24.02.2022
 %
 % LinProp Const:
 % a = LinProp(value)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.0
 % Michael Wollensack METAS - 17.09.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 24.02.2022
 %
 % MCProp Const:
 % a = MCProp(value)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1127,6 +1127,7 @@ classdef MCProp
                 elseif ~x.IsArray && y.IsArray
                     z = MCProp(y.NetObject.RAdd(x.NetObject));
                 else
+                    [x, y] = MCProp.replicateSingletonDimensions(x, y);
                     z = MCProp(x.NetObject.Add(y.NetObject));
                 end
             end
@@ -1150,6 +1151,7 @@ classdef MCProp
                 elseif ~x.IsArray && y.IsArray
                     z = MCProp(y.NetObject.RSubtract(x.NetObject));
                 else
+                    [x, y] = MCProp.replicateSingletonDimensions(x, y);
                     z = MCProp(x.NetObject.Subtract(y.NetObject));
                 end
             end
@@ -1171,27 +1173,7 @@ classdef MCProp
             elseif ~x.IsArray && y.IsArray
                 z = MCProp(y.NetObject.RMultiply(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = MCProp.replicateSingletonDimensions(x, y);
                 z = MCProp(x.NetObject.Multiply(y.NetObject));
             end
         end
@@ -1211,27 +1193,7 @@ classdef MCProp
             elseif ~x.IsArray && y.IsArray
                 z = MCProp(y.NetObject.RDivide(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = MCProp.replicateSingletonDimensions(x, y);
                 z = MCProp(x.NetObject.Divide(y.NetObject));
             end
         end
@@ -1946,6 +1908,27 @@ classdef MCProp
         end
     end
     methods(Static = true, Access = private)
+        function [x, y] = replicateSingletonDimensions(x, y)
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                throwAsCaller(MException('MATLAB:sizeDimensionsMustMatch', 'Arrays have incompatible sizes for this operation.'));
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            if any(doRepX)
+                repX = ones(1, dims);
+                repX(doRepX) = sizeY(doRepX);
+                x = repmat(x, repX);
+            end
+
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            if any(doRepY)
+                repY = ones(1, dims);
+                repY(doRepY) = sizeX(doRepY);
+                y = repmat(y, repY);
+            end
+        end
         function h = UncHelper()
             h = NET.createGeneric('Metas.UncLib.Core.Unc.GenericUnc', {'Metas.UncLib.MCProp.UncList', 'Metas.UncLib.MCProp.UncNumber'});
         end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1211,6 +1211,27 @@ classdef MCProp
             elseif ~x.IsArray && y.IsArray
                 z = MCProp(y.NetObject.RDivide(x.NetObject));
             else
+                
+                dims = max(ndims(x), ndims(y));
+                sizeX = size(x, 1:dims);
+                sizeY = size(y, 1:dims);
+                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                    error('Arrays have incompatible sizes for this operation.');
+                end
+                doRepX = sizeX ~= sizeY & sizeX == 1;
+                if any(doRepX)
+                    repX = ones(1, dims);
+                    repX(doRepX) = sizeY(doRepX);
+                    x = repmat(x, repX);
+                end
+
+                doRepY = sizeY ~= sizeX & sizeY == 1;
+                if any(doRepY)
+                    repY = ones(1, dims);
+                    repY(doRepY) = sizeX(doRepY);
+                    y = repmat(y, repY);
+                end
+                
                 z = MCProp(x.NetObject.Divide(y.NetObject));
             end
         end


### PR DESCRIPTION
The functions plus (+), minus (-), ldivide (.\) and rdivide (./) did not replicate singleton dimensions, as matlab's implementation for numeric variables does, i.e. `[1, 2, 3]+4` should be treated as `[1, 2, 3]+[4, 4, 4]`. I had previously added this behavior for times (*), so I moved that part of the code to a static private function and used it in plus, minus, rdivide. The function ldivide calls rdivide, so it now also works in this regard.

I added tests to https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests in the files [test_array_division.m](https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/blob/main/tests/test_array_division.m) and  [test_addition_subtraction.m](https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/blob/main/tests/test_addition_subtraction.m). These tests now all pass, except for rdivide/ldivide with DistProp variables. However, the errors are due to slight numerical differences, which likely are unavoidable.