### PR TITLE
Improved display behavior

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1211,6 +1211,27 @@ classdef DistProp
             elseif ~x.IsArray && y.IsArray
                 z = DistProp(y.NetObject.RDivide(x.NetObject));
             else
+                
+                dims = max(ndims(x), ndims(y));
+                sizeX = size(x, 1:dims);
+                sizeY = size(y, 1:dims);
+                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                    error('Arrays have incompatible sizes for this operation.');
+                end
+                doRepX = sizeX ~= sizeY & sizeX == 1;
+                if any(doRepX)
+                    repX = ones(1, dims);
+                    repX(doRepX) = sizeY(doRepX);
+                    x = repmat(x, repX);
+                end
+
+                doRepY = sizeY ~= sizeX & sizeY == 1;
+                if any(doRepY)
+                    repY = ones(1, dims);
+                    repY(doRepY) = sizeX(doRepY);
+                    y = repmat(y, repY);
+                end
+                
                 z = DistProp(x.NetObject.Divide(y.NetObject));
             end
         end

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.0
 % Michael Wollensack METAS - 17.09.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 24.02.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -1127,6 +1127,7 @@ classdef DistProp
                 elseif ~x.IsArray && y.IsArray
                     z = DistProp(y.NetObject.RAdd(x.NetObject));
                 else
+                    [x, y] = DistProp.replicateSingletonDimensions(x, y);
                     z = DistProp(x.NetObject.Add(y.NetObject));
                 end
             end
@@ -1150,6 +1151,7 @@ classdef DistProp
                 elseif ~x.IsArray && y.IsArray
                     z = DistProp(y.NetObject.RSubtract(x.NetObject));
                 else
+                    [x, y] = DistProp.replicateSingletonDimensions(x, y);
                     z = DistProp(x.NetObject.Subtract(y.NetObject));
                 end
             end
@@ -1171,27 +1173,7 @@ classdef DistProp
             elseif ~x.IsArray && y.IsArray
                 z = DistProp(y.NetObject.RMultiply(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = DistProp.replicateSingletonDimensions(x, y);
                 z = DistProp(x.NetObject.Multiply(y.NetObject));
             end
         end
@@ -1211,27 +1193,7 @@ classdef DistProp
             elseif ~x.IsArray && y.IsArray
                 z = DistProp(y.NetObject.RDivide(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = DistProp.replicateSingletonDimensions(x, y);
                 z = DistProp(x.NetObject.Divide(y.NetObject));
             end
         end
@@ -1946,6 +1908,27 @@ classdef DistProp
         end
     end
     methods(Static = true, Access = private)
+        function [x, y] = replicateSingletonDimensions(x, y)
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                throwAsCaller(MException('MATLAB:sizeDimensionsMustMatch', 'Arrays have incompatible sizes for this operation.'));
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            if any(doRepX)
+                repX = ones(1, dims);
+                repX(doRepX) = sizeY(doRepX);
+                x = repmat(x, repX);
+            end
+
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            if any(doRepY)
+                repY = ones(1, dims);
+                repY(doRepY) = sizeX(doRepY);
+                y = repmat(y, repY);
+            end
+        end
         function h = UncHelper()
             h = NET.createGeneric('Metas.UncLib.Core.Unc.GenericUnc', {'Metas.UncLib.DistProp.UncList', 'Metas.UncLib.DistProp.UncNumber'});
         end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.0
 % Michael Wollensack METAS - 17.09.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 24.02.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -1127,6 +1127,7 @@ classdef LinProp
                 elseif ~x.IsArray && y.IsArray
                     z = LinProp(y.NetObject.RAdd(x.NetObject));
                 else
+                    [x, y] = LinProp.replicateSingletonDimensions(x, y);
                     z = LinProp(x.NetObject.Add(y.NetObject));
                 end
             end
@@ -1150,6 +1151,7 @@ classdef LinProp
                 elseif ~x.IsArray && y.IsArray
                     z = LinProp(y.NetObject.RSubtract(x.NetObject));
                 else
+                    [x, y] = LinProp.replicateSingletonDimensions(x, y);
                     z = LinProp(x.NetObject.Subtract(y.NetObject));
                 end
             end
@@ -1171,27 +1173,7 @@ classdef LinProp
             elseif ~x.IsArray && y.IsArray
                 z = LinProp(y.NetObject.RMultiply(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = LinProp.replicateSingletonDimensions(x, y);
                 z = LinProp(x.NetObject.Multiply(y.NetObject));
             end
         end
@@ -1211,27 +1193,7 @@ classdef LinProp
             elseif ~x.IsArray && y.IsArray
                 z = LinProp(y.NetObject.RDivide(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = LinProp.replicateSingletonDimensions(x, y);
                 z = LinProp(x.NetObject.Divide(y.NetObject));
             end
         end
@@ -1946,6 +1908,27 @@ classdef LinProp
         end
     end
     methods(Static = true, Access = private)
+        function [x, y] = replicateSingletonDimensions(x, y)
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                throwAsCaller(MException('MATLAB:sizeDimensionsMustMatch', 'Arrays have incompatible sizes for this operation.'));
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            if any(doRepX)
+                repX = ones(1, dims);
+                repX(doRepX) = sizeY(doRepX);
+                x = repmat(x, repX);
+            end
+
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            if any(doRepY)
+                repY = ones(1, dims);
+                repY(doRepY) = sizeX(doRepY);
+                y = repmat(y, repY);
+            end
+        end
         function h = UncHelper()
             h = NET.createGeneric('Metas.UncLib.Core.Unc.GenericUnc', {'Metas.UncLib.LinProp.UncList', 'Metas.UncLib.LinProp.UncNumber'});
         end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1211,6 +1211,27 @@ classdef LinProp
             elseif ~x.IsArray && y.IsArray
                 z = LinProp(y.NetObject.RDivide(x.NetObject));
             else
+                
+                dims = max(ndims(x), ndims(y));
+                sizeX = size(x, 1:dims);
+                sizeY = size(y, 1:dims);
+                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                    error('Arrays have incompatible sizes for this operation.');
+                end
+                doRepX = sizeX ~= sizeY & sizeX == 1;
+                if any(doRepX)
+                    repX = ones(1, dims);
+                    repX(doRepX) = sizeY(doRepX);
+                    x = repmat(x, repX);
+                end
+
+                doRepY = sizeY ~= sizeX & sizeY == 1;
+                if any(doRepY)
+                    repY = ones(1, dims);
+                    repY(doRepY) = sizeX(doRepY);
+                    y = repmat(y, repY);
+                end
+                
                 z = LinProp(x.NetObject.Divide(y.NetObject));
             end
         end

--- a/@LinProp/displayBudget.m
+++ b/@LinProp/displayBudget.m
@@ -1,0 +1,93 @@
+function displayBudget(obj, part)
+
+    varName = inputname(1);
+
+    if numel(obj) ~= 1
+        error('Can only show budget for scalars');
+    end
+    
+    if obj.IsComplex
+        if nargin < 2
+            error('Input argument ''part'' not specified.');
+        end
+        
+        switch (part)
+            case 'real'
+                obj = real(obj);
+                varName = sprintf('real(%s)', varName);
+            case 'imag'
+                obj = imag(obj);
+                varName = sprintf('imag(%s)', varName);
+            otherwise
+                error('Input argument ''part'' must be ''real'' or ''imag''.');
+        end
+    end
+
+    tree = Metas.UncLib.LinProp.UncBudget.ComputeTreeUncBudget(obj.NetObject);
+    if tree.Length == 0
+        fprintf('\n  Variable %s has no uncertainty contributions.\n', varName);
+        return;
+    end
+    
+    fprintf('\n  Budget of %s:\n', varName);
+    
+    [description, componenent, percentage] = parseSubTree(tree);
+
+    nTableRows = numel(description);
+    maxDescriptionLength = max(cellfun(@numel, description));
+
+    description = sprintf(['%-' num2str(maxDescriptionLength) 's'], description);
+    description = reshape(description, [], nTableRows);
+
+    componenent = LinProp.toCharColumn(componenent);
+    componenent = reshape(componenent, [], nTableRows);
+
+    percentage = sprintf('%3.2f%%\n', percentage);
+    percentage = reshape(percentage, [], nTableRows);
+
+    spacing = 4;
+
+    text = [...
+        description; ...
+        repmat(' ', spacing, nTableRows); ...
+        componenent; ...
+        repmat(' ', spacing, nTableRows); ...
+        percentage ...
+    ];
+    fprintf('<strong>    Description</strong>%*s<strong>Component</strong>    <strong>Percentage</strong>\n', ...
+        size(description, 1) - numel('    Description') - numel('Component') + size(componenent, 1) + spacing, '');
+    fprintf('%s\n', text);
+end
+    
+function [description, componenent, percentage] = parseSubTree(tree, level)
+    description = strings(1, 0);
+    componenent = zeros(1, 0);
+    percentage = zeros(1, 0);
+    
+    if nargin == 1
+        level = 4;
+    end
+
+    for ii = 1:tree.Length
+        
+        [subTest, subComponent, subPercentage] = parseSubTree(tree(ii).SubItems, level+2);
+        
+        description = [...
+            description, ...
+            sprintf('%s%s', repmat(' ', 1, level), tree(ii).ShortDescription), ...
+            subTest...
+        ];
+        
+        componenent = [...
+            componenent, ...
+            tree(ii).UncComponent, ...
+            subComponent...
+        ];
+        
+        percentage = [...
+            percentage, ...
+            tree(ii).UncPercentage, ...
+            subPercentage...
+        ];
+    end
+end

--- a/@LinProp/displayScalarObject.m
+++ b/@LinProp/displayScalarObject.m
@@ -1,0 +1,36 @@
+function displayScalarObject(obj)
+    name = matlab.mixin.CustomDisplay.getClassNameForHeader(obj);
+    fprintf('    %s:\n    %s\n\n', name, LinProp.toUncCharColumn(get_value(obj), get_stdunc(obj)));
+    
+    stack = dbstack();
+    
+    if numel(stack) == 1
+        if obj.IsComplex
+            linkStrReal = sprintf('<a href="%s">Budget of real part</a>',getBudgetLink(inputname(1), class(obj), 'real'));
+            linkStrImag = sprintf('<a href="%s">Budget or imag part</a>',getBudgetLink(inputname(1), class(obj), 'imag'));
+            linkStr = [linkStrReal, ', ', linkStrImag];
+        else
+            linkStr = sprintf('<a href="%s">Budget</a>',getBudgetLink(inputname(1), class(obj), ''));
+        end
+
+        methodsStr = sprintf('<a href="matlab:methods(''%s'')">Methods</a>',class(obj));
+
+        fprintf('Show %s, %s.\n',linkStr, methodsStr);
+    end
+end
+
+function link=getBudgetLink(varName, class, part)
+
+    if nargin < 3
+        partStr = '';
+    else
+        partStr = sprintf(', ''%s''', part);
+    end
+
+    link=sprintf(['matlab:if exist(''%s'', ''var'')&&isa(%s, ''%s''), ', ...
+        'displayBudget(%s%s); ', ...
+        'else, ', ...
+        'fprintf(''Unable to display budget. %s refers to a deleted object.\\n''), ', ...
+        'end'], ...
+        varName,varName,class,varName,partStr,varName);
+end

--- a/@LinProp/eig.m
+++ b/@LinProp/eig.m
@@ -27,7 +27,7 @@ n2 = n(2);
 
 if (length(varargin) == 0)
     if (n1 ~= n2)
-        throw('Matrix must be square');
+        error('Matrix must be square');
     end
     if (~isComplex)
         symmetric = true;

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.0
 % Michael Wollensack METAS - 17.09.2021
-% Dion Timmermann PTB - 17.09.2021
+% Dion Timmermann PTB - 24.02.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -1127,6 +1127,7 @@ classdef MCProp
                 elseif ~x.IsArray && y.IsArray
                     z = MCProp(y.NetObject.RAdd(x.NetObject));
                 else
+                    [x, y] = MCProp.replicateSingletonDimensions(x, y);
                     z = MCProp(x.NetObject.Add(y.NetObject));
                 end
             end
@@ -1150,6 +1151,7 @@ classdef MCProp
                 elseif ~x.IsArray && y.IsArray
                     z = MCProp(y.NetObject.RSubtract(x.NetObject));
                 else
+                    [x, y] = MCProp.replicateSingletonDimensions(x, y);
                     z = MCProp(x.NetObject.Subtract(y.NetObject));
                 end
             end
@@ -1171,27 +1173,7 @@ classdef MCProp
             elseif ~x.IsArray && y.IsArray
                 z = MCProp(y.NetObject.RMultiply(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = MCProp.replicateSingletonDimensions(x, y);
                 z = MCProp(x.NetObject.Multiply(y.NetObject));
             end
         end
@@ -1211,27 +1193,7 @@ classdef MCProp
             elseif ~x.IsArray && y.IsArray
                 z = MCProp(y.NetObject.RDivide(x.NetObject));
             else
-                
-                dims = max(ndims(x), ndims(y));
-                sizeX = size(x, 1:dims);
-                sizeY = size(y, 1:dims);
-                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
-                    error('Arrays have incompatible sizes for this operation.');
-                end
-                doRepX = sizeX ~= sizeY & sizeX == 1;
-                if any(doRepX)
-                    repX = ones(1, dims);
-                    repX(doRepX) = sizeY(doRepX);
-                    x = repmat(x, repX);
-                end
-
-                doRepY = sizeY ~= sizeX & sizeY == 1;
-                if any(doRepY)
-                    repY = ones(1, dims);
-                    repY(doRepY) = sizeX(doRepY);
-                    y = repmat(y, repY);
-                end
-                
+                [x, y] = MCProp.replicateSingletonDimensions(x, y);
                 z = MCProp(x.NetObject.Divide(y.NetObject));
             end
         end
@@ -1946,6 +1908,27 @@ classdef MCProp
         end
     end
     methods(Static = true, Access = private)
+        function [x, y] = replicateSingletonDimensions(x, y)
+            dims = max(ndims(x), ndims(y));
+            sizeX = size(x, 1:dims);
+            sizeY = size(y, 1:dims);
+            if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                throwAsCaller(MException('MATLAB:sizeDimensionsMustMatch', 'Arrays have incompatible sizes for this operation.'));
+            end
+            doRepX = sizeX ~= sizeY & sizeX == 1;
+            if any(doRepX)
+                repX = ones(1, dims);
+                repX(doRepX) = sizeY(doRepX);
+                x = repmat(x, repX);
+            end
+
+            doRepY = sizeY ~= sizeX & sizeY == 1;
+            if any(doRepY)
+                repY = ones(1, dims);
+                repY(doRepY) = sizeX(doRepY);
+                y = repmat(y, repY);
+            end
+        end
         function h = UncHelper()
             h = NET.createGeneric('Metas.UncLib.Core.Unc.GenericUnc', {'Metas.UncLib.MCProp.UncList', 'Metas.UncLib.MCProp.UncNumber'});
         end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1211,6 +1211,27 @@ classdef MCProp
             elseif ~x.IsArray && y.IsArray
                 z = MCProp(y.NetObject.RDivide(x.NetObject));
             else
+                
+                dims = max(ndims(x), ndims(y));
+                sizeX = size(x, 1:dims);
+                sizeY = size(y, 1:dims);
+                if any(sizeX ~= sizeY & sizeX ~= 1 & sizeY ~= 1)
+                    error('Arrays have incompatible sizes for this operation.');
+                end
+                doRepX = sizeX ~= sizeY & sizeX == 1;
+                if any(doRepX)
+                    repX = ones(1, dims);
+                    repX(doRepX) = sizeY(doRepX);
+                    x = repmat(x, repX);
+                end
+
+                doRepY = sizeY ~= sizeX & sizeY == 1;
+                if any(doRepY)
+                    repY = ones(1, dims);
+                    repY(doRepY) = sizeX(doRepY);
+                    y = repmat(y, repY);
+                end
+                
                 z = MCProp(x.NetObject.Divide(y.NetObject));
             end
         end


### PR DESCRIPTION
At the moment, this is not a real pull-request, more an info and request for comments.

To help me debug some code, I wanted a nicer display of variables in the command line. The code has not been fully tested and currelty is only implemented for LinProp variables.

Display of a scalar in the command line:
```
>> LinProp(rand, rand)

ans = 

    LinProp:
     (0.6171 ± 0.2653)

Show Budget, Methods.
```

The words 'Buget' and 'Methods' are links. Clicking on the 'Budget' link prints the following:
```
  Budget of ans:
    Description                                       Component    Percentage
    Unknown Id                                           0.2653    100.00%
      B5-80-29-AB-36-A1-4C-8C-8D-8D-B9-B8-6F-EB-0A-07    0.2653    100.00%

```

Matricies are printed column-wise:
```
>> LinProp(rand(4, 6))

ans = 

    4×6 LinProp:

  Columns 1 through 4
     (0.8244 ± 0)     (0.5841 ± 0)     ( 0.8178 ± 0)     (0.4253 ± 0)
     (0.9827 ± 0)     (0.1078 ± 0)     ( 0.2607 ± 0)     (0.3127 ± 0)
     (0.7302 ± 0)     (0.9063 ± 0)     ( 0.5944 ± 0)     (0.1615 ± 0)
     (0.3439 ± 0)     (0.8797 ± 0)     (0.02251 ± 0)     (0.1788 ± 0)

  Columns 5 through 6
     ( 0.4229 ± 0)     (0.6959 ± 0)
     (0.09423 ± 0)     (0.6999 ± 0)
     ( 0.5985 ± 0)     (0.6385 ± 0)
     ( 0.4709 ± 0)     (0.0336 ± 0)

Show Methods.
```

This also works with complex matricies of more than 2 dimensions:
```
>> LinProp(rand(3, 2, 2))+1i*LinProp(rand(3, 2, 2))

ans = 

    3×2×2 LinProp:

(:,:,1) =

     ( 0.7788 ± 0) + (0.6377 ± 0)i     (0.2665 ± 0) + (0.6761 ± 0)i
     ( 0.4235 ± 0) + (0.9577 ± 0)i     (0.1537 ± 0) + (0.2891 ± 0)i
     (0.09082 ± 0) + (0.2407 ± 0)i     ( 0.281 ± 0) + (0.6718 ± 0)i


(:,:,2) =

     (0.4401 ± 0) + ( 0.6951 ± 0)i     (0.8754 ± 0) + ( 0.224 ± 0)i
     (0.5271 ± 0) + (0.06799 ± 0)i     (0.5181 ± 0) + (0.6678 ± 0)i
     (0.4574 ± 0) + ( 0.2548 ± 0)i     (0.9436 ± 0) + (0.8444 ± 0)i

Show Methods.
```