### PR TITLE
Performance improvements for subsasgn()

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 18.03.2022
+% Dion Timmermann PTB - 22.03.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -540,6 +540,8 @@ classdef DistProp
                 end
             end
             
+            newA = strcmp(class(A), 'double'); %#ok<STISA>
+            
             sizeA = size(A);
             numelA = prod(sizeA);
             sizeB = size(B);
@@ -595,7 +597,7 @@ classdef DistProp
             % Replace ':' placeholders 
             % Note: The last dimension can always be used to address
             % all following dimensions.
-            if numelA == 0
+            if all(sizeA == 0)
                 % If A has not been defined yet, the dots (:) refer to the
                 % size of B.
                 if numel(sizeB) ~= sum(cellfun(@numel, I)>1 | strcmp(I, ':'))    % Singleton dimensions of B are ignored, except the dimensions already match.
@@ -651,14 +653,15 @@ classdef DistProp
                 end
             end
 
+            % Assignment of no elements to an empty/new object.
             if any(I_isempty) && numelA == 0
                 if numelB <= 1
                     s = I_maxIndex;
                     if numel(s) < 2
-                        if ~isemptyB
-                            s = [s zeros(1,2-numel(s))];
-                        else
+                        if isemptyB && newA
                             s = [ones(1,2-numel(s)) s];
+                        else
+                            s = [s zeros(1,2-numel(s))];
                         end
                     else
                         lastNonSingletonDimension = find(s~=1, 1, 'last');
@@ -669,10 +672,9 @@ classdef DistProp
                 else 
                     error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                 end
-            end
             
             % Linear indexing
-            if dimI == 1
+            elseif dimI == 1
                 % Linear indexing follows some specific rules
                 
                 if ~isscalarB && numel(I{1}) ~= numelB
@@ -736,9 +738,9 @@ classdef DistProp
                         I_numel(ii) = numel(I{ii});
                     end
                     
-                    sizeI_reduced = I_numel(I_numel > 1);
-                    sizeB_reduced = sizeB(sizeB > 1);
-                    if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
+                    sizeI_reduced = I_numel(I_numel ~= 1);
+                    sizeB_reduced = sizeB(sizeB ~= 1);
+                    if ~isequal(sizeI_reduced, sizeB_reduced) && not(any(I_numel == 0) && any(sizeB == 0))
                         error('Unable to perform assignment because the size of the left side is %s and the size of the right side is %s.', ...
                         strjoin(string(I_numel), '-by-'), ...
                         strjoin(string(sizeB), '-by-'));

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -279,9 +279,9 @@ classdef DistProp
             else
                 if obj.IsComplex
                     sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(real(obj)), df) ')'];       
+                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
                     simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' Â± ' num2str(get_stdunc(imag(obj)), df) ')'];
+                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
                     if (get_value(imag(obj)) < 0)
                         s = [sreal ' - ' simag 'i'];
                     else
@@ -289,7 +289,7 @@ classdef DistProp
                     end
                 else        
                     s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' Â± ' num2str(get_stdunc(obj), df) ')'];
+                         ' ± ' num2str(get_stdunc(obj), df) ')'];
                 end    
                 if (get_value(real(obj)) < 0)
                     s = ['  -' s];

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 24.02.2022
+% Dion Timmermann PTB - 18.03.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -528,20 +528,27 @@ classdef DistProp
             I = S.subs;
             dimI = numel(I);
             
-            % Convert logical indexes to subscripts
-            isLogicalIndex = cellfun(@islogical, I);
-            I(isLogicalIndex) = cellfun(@find, I(isLogicalIndex), 'UniformOutput', false);
-            
-            % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
-            if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), I(~isLogicalIndex)))
-                error('Array indices must be positive integers or logical values.');
+            % Convert logical indexes to subscripts and check subscripts
+            for ii = dimI:-1:1
+                if islogical(I{ii})
+                    I{ii} = find(I{ii});
+                else
+                    v = I{ii}(:);
+                    if any(ceil(v)~=v | isinf(v) | v <= 0)
+                        error('Array indices must be positive integers or logical values.');
+                    end
+                end
             end
             
             sizeA = size(A);
             numelA = prod(sizeA);
+            sizeB = size(B);
+            numelB = prod(sizeB);
+            isemptyB = (numelB == 0);
+            isscalarB = (numelB == 1);
             
             % Special case of null assignment to remove elements
-            if isempty(B) && isa(B, 'double')
+            if isemptyB && isa(B, 'double')
                 if sum(~strcmp(I, ':')) > 1
                     error('A null assignment can have only one non-colon index.');
                 else
@@ -576,9 +583,12 @@ classdef DistProp
             if ~isa(B, 'DistProp')
                 B = DistProp(B);
             end
-            if A.IsComplex && ~B.IsComplex
+            isComplexA = A.IsComplex;
+            isComplexB = B.IsComplex;
+            isComplex = isComplexA || isComplexB;
+            if isComplexA && ~isComplexB
                 B = complex(B);
-            elseif ~A.IsComplex && B.IsComplex
+            elseif ~isComplexA && isComplexB
                 A = complex(A);
             end
             
@@ -588,28 +598,28 @@ classdef DistProp
             if numelA == 0
                 % If A has not been defined yet, the dots (:) refer to the
                 % size of B.
-                sizeB = size(B);
                 if numel(sizeB) ~= sum(cellfun(@numel, I)>1 | strcmp(I, ':'))    % Singleton dimensions of B are ignored, except the dimensions already match.
-                    sizeB = sizeB(sizeB>1);
-                    sizeB = [sizeB ones(1, numel(I)-numel(sizeB))];
+                    sizeB_reduced = sizeB(sizeB>1);
+                    sizeB_reduced = [sizeB_reduced ones(1, numel(I)-numel(sizeB_reduced))];
+                else
+                    sizeB_reduced = sizeB;
                 end
-                numelB = prod(sizeB);
                 tmpProd = 1;
                 idx = 1;
                 if any(strcmp(I, ':'))
-                    if dimI < sum(sizeB>1)
+                    if dimI < sum(sizeB_reduced>1)
                         error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                     end
                     for ii = 1:(dimI-1)  % Dimensions except the last one
                         if strcmp(I{ii}, ':')
-                            I{ii} = 1:sizeB(idx);
-                            tmpProd = tmpProd * sizeB(idx);
+                            I{ii} = 1:sizeB_reduced(idx);
+                            tmpProd = tmpProd * sizeB_reduced(idx);
                             idx = idx + 1;
                         elseif numel(I{ii}) > 1
-                            if numel(I{ii}) ~= sizeB(idx)
+                            if numel(I{ii}) ~= sizeB_reduced(idx)
                                 error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                             end
-                            tmpProd = tmpProd * sizeB(idx);
+                            tmpProd = tmpProd * sizeB_reduced(idx);
                             idx = idx + 1;
                         end
                     end
@@ -632,15 +642,20 @@ classdef DistProp
                 end
             end
             
-            I_isempty = cellfun(@isempty, I);
-            I_maxIndex = zeros(size(I));
-            I_maxIndex(~I_isempty) = cellfun(@(x) double(max(x)), I(~I_isempty));
+            for ii = numel(I):-1:1
+                I_isempty = isempty(I{ii});
+                if I_isempty
+                    I_maxIndex(ii) = 0;
+                else
+                    I_maxIndex(ii) = double(max(I{ii}));
+                end
+            end
 
             if any(I_isempty) && numelA == 0
-                if numel(B) <= 1
+                if numelB <= 1
                     s = I_maxIndex;
                     if numel(s) < 2
-                        if ~isempty(B)
+                        if ~isemptyB
                             s = [s zeros(1,2-numel(s))];
                         else
                             s = [ones(1,2-numel(s)) s];
@@ -660,15 +675,15 @@ classdef DistProp
             if dimI == 1
                 % Linear indexing follows some specific rules
                 
-                if ~isscalar(B) && numel(I{1}) ~= numel(B)
+                if ~isscalarB && numel(I{1}) ~= numelB
                     error('Unable to perform assignment because the left and right sides have a different number of elements.');
                 end
                 
                 % Grow vector if necessary
                 if I_maxIndex > numelA
                     if numelA == 0
-                        A = DistProp(zeros(1, I_maxIndex));
-                        if B.IsComplex
+                        A = zeros(1, I_maxIndex, 'DistProp');
+                        if isComplex
                             A = complex(A);
                         end
                     elseif isrow(A)
@@ -685,10 +700,10 @@ classdef DistProp
                 bm = DistProp.Convert2UncArray(B);
                 dest_index = DistProp.IndexMatrix(I);
 
-                if isscalar(B)
+                if isscalarB
                     am.SetSameItem1d(int32(dest_index - 1), bm.GetItem1d(0));
                 else
-                    am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numel(B)-1)));
+                    am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numelB-1)));
                 end
                 
                 C = DistProp.Convert2DistProp(am);
@@ -697,7 +712,7 @@ classdef DistProp
             % Or subscript indexing / partial linear indexing
             else
   
-                if dimI < ndims(A)
+                if dimI < numel(sizeA)
                     % partial linear indexing
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
@@ -705,7 +720,9 @@ classdef DistProp
                 else
                     % Ignore empty and singleton dimensions that have been
                     % indexed but do not exist anyways.
-                    I_issingleton = cellfun(@(x) all(x == 1), I);
+                    for ii = dimI:-1:1
+                        I_issingleton(ii) = all(I{ii}(:) == 1);
+                    end
                     I_lastRelevant = [find(not(I_isempty | I_issingleton), 1, 'last') 2];
                     I_lastRelevant = I_lastRelevant(1);
                     I = I(1:min(dimI, max(numel(sizeA), I_lastRelevant)));
@@ -714,15 +731,16 @@ classdef DistProp
                 end
                 
                 % Check dimensions
-                if ~isscalar(B)
-                    sizeI = cellfun(@numel, I);
-                    sizeB = size(B);
+                if ~isscalarB
+                    for ii = dimI:-1:1
+                        I_numel(ii) = numel(I{ii});
+                    end
                     
-                    sizeI_reduced = sizeI(sizeI > 1);
+                    sizeI_reduced = I_numel(I_numel > 1);
                     sizeB_reduced = sizeB(sizeB > 1);
                     if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
                         error('Unable to perform assignment because the size of the left side is %s and the size of the right side is %s.', ...
-                        strjoin(string(sizeI), '-by-'), ...
+                        strjoin(string(I_numel), '-by-'), ...
                         strjoin(string(sizeB), '-by-'));
                     end
                     
@@ -735,7 +753,7 @@ classdef DistProp
                 sA_nI = [sizeA(1 : (dimI-1)), prod(sizeA(dimI:end))]; % size of A, when using the same number of dimensions as nI;
                 if any(I_maxIndex > sA_nI)
                     A2 = DistProp(zeros(max(I_maxIndex, sA_nI)));
-                    if B.IsComplex
+                    if isComplex
                         A2 = complex(A2);
                     end
                     if numel(A) == 0
@@ -758,10 +776,10 @@ classdef DistProp
                 bm = DistProp.Convert2UncArray(B);
                 dest_index = DistProp.IndexMatrix(I);
 
-                if isscalar(B)
+                if isscalarB
                     am.SetSameItemNd(int32(dest_index - 1), bm.GetItem1d(0));
                 else
-                    src_subs = arrayfun(@(x) 1:x, size(B), 'UniformOutput', false);
+                    src_subs = arrayfun(@(x) 1:x, sizeB, 'UniformOutput', false);
                     src_index  = DistProp.IndexMatrix(src_subs);
 
                     am.SetItemsNd(int32(dest_index - 1), bm.GetItemsNd(int32(src_index - 1)));

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 18.03.2022
+% Dion Timmermann PTB - 22.03.2022
 %
 % LinProp Const:
 % a = LinProp(value)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 24.02.2022
+% Dion Timmermann PTB - 18.03.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -528,20 +528,27 @@ classdef LinProp
             I = S.subs;
             dimI = numel(I);
             
-            % Convert logical indexes to subscripts
-            isLogicalIndex = cellfun(@islogical, I);
-            I(isLogicalIndex) = cellfun(@find, I(isLogicalIndex), 'UniformOutput', false);
-            
-            % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
-            if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), I(~isLogicalIndex)))
-                error('Array indices must be positive integers or logical values.');
+            % Convert logical indexes to subscripts and check subscripts
+            for ii = dimI:-1:1
+                if islogical(I{ii})
+                    I{ii} = find(I{ii});
+                else
+                    v = I{ii}(:);
+                    if any(ceil(v)~=v | isinf(v) | v <= 0)
+                        error('Array indices must be positive integers or logical values.');
+                    end
+                end
             end
             
             sizeA = size(A);
             numelA = prod(sizeA);
+            sizeB = size(B);
+            numelB = prod(sizeB);
+            isemptyB = (numelB == 0);
+            isscalarB = (numelB == 1);
             
             % Special case of null assignment to remove elements
-            if isempty(B) && isa(B, 'double')
+            if isemptyB && isa(B, 'double')
                 if sum(~strcmp(I, ':')) > 1
                     error('A null assignment can have only one non-colon index.');
                 else
@@ -576,9 +583,12 @@ classdef LinProp
             if ~isa(B, 'LinProp')
                 B = LinProp(B);
             end
-            if A.IsComplex && ~B.IsComplex
+            isComplexA = A.IsComplex;
+            isComplexB = B.IsComplex;
+            isComplex = isComplexA || isComplexB;
+            if isComplexA && ~isComplexB
                 B = complex(B);
-            elseif ~A.IsComplex && B.IsComplex
+            elseif ~isComplexA && isComplexB
                 A = complex(A);
             end
             
@@ -588,28 +598,28 @@ classdef LinProp
             if numelA == 0
                 % If A has not been defined yet, the dots (:) refer to the
                 % size of B.
-                sizeB = size(B);
                 if numel(sizeB) ~= sum(cellfun(@numel, I)>1 | strcmp(I, ':'))    % Singleton dimensions of B are ignored, except the dimensions already match.
-                    sizeB = sizeB(sizeB>1);
-                    sizeB = [sizeB ones(1, numel(I)-numel(sizeB))];
+                    sizeB_reduced = sizeB(sizeB>1);
+                    sizeB_reduced = [sizeB_reduced ones(1, numel(I)-numel(sizeB_reduced))];
+                else
+                    sizeB_reduced = sizeB;
                 end
-                numelB = prod(sizeB);
                 tmpProd = 1;
                 idx = 1;
                 if any(strcmp(I, ':'))
-                    if dimI < sum(sizeB>1)
+                    if dimI < sum(sizeB_reduced>1)
                         error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                     end
                     for ii = 1:(dimI-1)  % Dimensions except the last one
                         if strcmp(I{ii}, ':')
-                            I{ii} = 1:sizeB(idx);
-                            tmpProd = tmpProd * sizeB(idx);
+                            I{ii} = 1:sizeB_reduced(idx);
+                            tmpProd = tmpProd * sizeB_reduced(idx);
                             idx = idx + 1;
                         elseif numel(I{ii}) > 1
-                            if numel(I{ii}) ~= sizeB(idx)
+                            if numel(I{ii}) ~= sizeB_reduced(idx)
                                 error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                             end
-                            tmpProd = tmpProd * sizeB(idx);
+                            tmpProd = tmpProd * sizeB_reduced(idx);
                             idx = idx + 1;
                         end
                     end
@@ -632,15 +642,20 @@ classdef LinProp
                 end
             end
             
-            I_isempty = cellfun(@isempty, I);
-            I_maxIndex = zeros(size(I));
-            I_maxIndex(~I_isempty) = cellfun(@(x) double(max(x)), I(~I_isempty));
+            for ii = numel(I):-1:1
+                I_isempty = isempty(I{ii});
+                if I_isempty
+                    I_maxIndex(ii) = 0;
+                else
+                    I_maxIndex(ii) = double(max(I{ii}));
+                end
+            end
 
             if any(I_isempty) && numelA == 0
-                if numel(B) <= 1
+                if numelB <= 1
                     s = I_maxIndex;
                     if numel(s) < 2
-                        if ~isempty(B)
+                        if ~isemptyB
                             s = [s zeros(1,2-numel(s))];
                         else
                             s = [ones(1,2-numel(s)) s];
@@ -660,15 +675,15 @@ classdef LinProp
             if dimI == 1
                 % Linear indexing follows some specific rules
                 
-                if ~isscalar(B) && numel(I{1}) ~= numel(B)
+                if ~isscalarB && numel(I{1}) ~= numelB
                     error('Unable to perform assignment because the left and right sides have a different number of elements.');
                 end
                 
                 % Grow vector if necessary
                 if I_maxIndex > numelA
                     if numelA == 0
-                        A = LinProp(zeros(1, I_maxIndex));
-                        if B.IsComplex
+                        A = zeros(1, I_maxIndex, 'LinProp');
+                        if isComplex
                             A = complex(A);
                         end
                     elseif isrow(A)
@@ -685,10 +700,10 @@ classdef LinProp
                 bm = LinProp.Convert2UncArray(B);
                 dest_index = LinProp.IndexMatrix(I);
 
-                if isscalar(B)
+                if isscalarB
                     am.SetSameItem1d(int32(dest_index - 1), bm.GetItem1d(0));
                 else
-                    am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numel(B)-1)));
+                    am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numelB-1)));
                 end
                 
                 C = LinProp.Convert2LinProp(am);
@@ -697,7 +712,7 @@ classdef LinProp
             % Or subscript indexing / partial linear indexing
             else
   
-                if dimI < ndims(A)
+                if dimI < numel(sizeA)
                     % partial linear indexing
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
@@ -705,7 +720,9 @@ classdef LinProp
                 else
                     % Ignore empty and singleton dimensions that have been
                     % indexed but do not exist anyways.
-                    I_issingleton = cellfun(@(x) all(x == 1), I);
+                    for ii = dimI:-1:1
+                        I_issingleton(ii) = all(I{ii}(:) == 1);
+                    end
                     I_lastRelevant = [find(not(I_isempty | I_issingleton), 1, 'last') 2];
                     I_lastRelevant = I_lastRelevant(1);
                     I = I(1:min(dimI, max(numel(sizeA), I_lastRelevant)));
@@ -714,15 +731,16 @@ classdef LinProp
                 end
                 
                 % Check dimensions
-                if ~isscalar(B)
-                    sizeI = cellfun(@numel, I);
-                    sizeB = size(B);
+                if ~isscalarB
+                    for ii = dimI:-1:1
+                        I_numel(ii) = numel(I{ii});
+                    end
                     
-                    sizeI_reduced = sizeI(sizeI > 1);
+                    sizeI_reduced = I_numel(I_numel > 1);
                     sizeB_reduced = sizeB(sizeB > 1);
                     if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
                         error('Unable to perform assignment because the size of the left side is %s and the size of the right side is %s.', ...
-                        strjoin(string(sizeI), '-by-'), ...
+                        strjoin(string(I_numel), '-by-'), ...
                         strjoin(string(sizeB), '-by-'));
                     end
                     
@@ -735,7 +753,7 @@ classdef LinProp
                 sA_nI = [sizeA(1 : (dimI-1)), prod(sizeA(dimI:end))]; % size of A, when using the same number of dimensions as nI;
                 if any(I_maxIndex > sA_nI)
                     A2 = LinProp(zeros(max(I_maxIndex, sA_nI)));
-                    if B.IsComplex
+                    if isComplex
                         A2 = complex(A2);
                     end
                     if numel(A) == 0
@@ -758,10 +776,10 @@ classdef LinProp
                 bm = LinProp.Convert2UncArray(B);
                 dest_index = LinProp.IndexMatrix(I);
 
-                if isscalar(B)
+                if isscalarB
                     am.SetSameItemNd(int32(dest_index - 1), bm.GetItem1d(0));
                 else
-                    src_subs = arrayfun(@(x) 1:x, size(B), 'UniformOutput', false);
+                    src_subs = arrayfun(@(x) 1:x, sizeB, 'UniformOutput', false);
                     src_index  = LinProp.IndexMatrix(src_subs);
 
                     am.SetItemsNd(int32(dest_index - 1), bm.GetItemsNd(int32(src_index - 1)));

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -540,6 +540,8 @@ classdef LinProp
                 end
             end
             
+            newA = strcmp(class(A), 'double'); %#ok<STISA>
+            
             sizeA = size(A);
             numelA = prod(sizeA);
             sizeB = size(B);
@@ -595,7 +597,7 @@ classdef LinProp
             % Replace ':' placeholders 
             % Note: The last dimension can always be used to address
             % all following dimensions.
-            if numelA == 0
+            if all(sizeA == 0)
                 % If A has not been defined yet, the dots (:) refer to the
                 % size of B.
                 if numel(sizeB) ~= sum(cellfun(@numel, I)>1 | strcmp(I, ':'))    % Singleton dimensions of B are ignored, except the dimensions already match.
@@ -651,14 +653,15 @@ classdef LinProp
                 end
             end
 
+            % Assignment of no elements to an empty/new object.
             if any(I_isempty) && numelA == 0
                 if numelB <= 1
                     s = I_maxIndex;
                     if numel(s) < 2
-                        if ~isemptyB
-                            s = [s zeros(1,2-numel(s))];
-                        else
+                        if isemptyB && newA
                             s = [ones(1,2-numel(s)) s];
+                        else
+                            s = [s zeros(1,2-numel(s))];
                         end
                     else
                         lastNonSingletonDimension = find(s~=1, 1, 'last');
@@ -669,10 +672,9 @@ classdef LinProp
                 else 
                     error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                 end
-            end
             
             % Linear indexing
-            if dimI == 1
+            elseif dimI == 1
                 % Linear indexing follows some specific rules
                 
                 if ~isscalarB && numel(I{1}) ~= numelB
@@ -736,9 +738,9 @@ classdef LinProp
                         I_numel(ii) = numel(I{ii});
                     end
                     
-                    sizeI_reduced = I_numel(I_numel > 1);
-                    sizeB_reduced = sizeB(sizeB > 1);
-                    if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
+                    sizeI_reduced = I_numel(I_numel ~= 1);
+                    sizeB_reduced = sizeB(sizeB ~= 1);
+                    if ~isequal(sizeI_reduced, sizeB_reduced) && not(any(I_numel == 0) && any(sizeB == 0))
                         error('Unable to perform assignment because the size of the left side is %s and the size of the right side is %s.', ...
                         strjoin(string(I_numel), '-by-'), ...
                         strjoin(string(sizeB), '-by-'));

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 24.02.2022
+% Dion Timmermann PTB - 18.03.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -528,20 +528,27 @@ classdef MCProp
             I = S.subs;
             dimI = numel(I);
             
-            % Convert logical indexes to subscripts
-            isLogicalIndex = cellfun(@islogical, I);
-            I(isLogicalIndex) = cellfun(@find, I(isLogicalIndex), 'UniformOutput', false);
-            
-            % check if non-logical indexes have positive integer values (rounding has no effect and not inf, nan also fails this test).
-            if any(cellfun(@(v) any(ceil(v)~=v | isinf(v) | v <= 0), I(~isLogicalIndex)))
-                error('Array indices must be positive integers or logical values.');
+            % Convert logical indexes to subscripts and check subscripts
+            for ii = dimI:-1:1
+                if islogical(I{ii})
+                    I{ii} = find(I{ii});
+                else
+                    v = I{ii}(:);
+                    if any(ceil(v)~=v | isinf(v) | v <= 0)
+                        error('Array indices must be positive integers or logical values.');
+                    end
+                end
             end
             
             sizeA = size(A);
             numelA = prod(sizeA);
+            sizeB = size(B);
+            numelB = prod(sizeB);
+            isemptyB = (numelB == 0);
+            isscalarB = (numelB == 1);
             
             % Special case of null assignment to remove elements
-            if isempty(B) && isa(B, 'double')
+            if isemptyB && isa(B, 'double')
                 if sum(~strcmp(I, ':')) > 1
                     error('A null assignment can have only one non-colon index.');
                 else
@@ -576,9 +583,12 @@ classdef MCProp
             if ~isa(B, 'MCProp')
                 B = MCProp(B);
             end
-            if A.IsComplex && ~B.IsComplex
+            isComplexA = A.IsComplex;
+            isComplexB = B.IsComplex;
+            isComplex = isComplexA || isComplexB;
+            if isComplexA && ~isComplexB
                 B = complex(B);
-            elseif ~A.IsComplex && B.IsComplex
+            elseif ~isComplexA && isComplexB
                 A = complex(A);
             end
             
@@ -588,28 +598,28 @@ classdef MCProp
             if numelA == 0
                 % If A has not been defined yet, the dots (:) refer to the
                 % size of B.
-                sizeB = size(B);
                 if numel(sizeB) ~= sum(cellfun(@numel, I)>1 | strcmp(I, ':'))    % Singleton dimensions of B are ignored, except the dimensions already match.
-                    sizeB = sizeB(sizeB>1);
-                    sizeB = [sizeB ones(1, numel(I)-numel(sizeB))];
+                    sizeB_reduced = sizeB(sizeB>1);
+                    sizeB_reduced = [sizeB_reduced ones(1, numel(I)-numel(sizeB_reduced))];
+                else
+                    sizeB_reduced = sizeB;
                 end
-                numelB = prod(sizeB);
                 tmpProd = 1;
                 idx = 1;
                 if any(strcmp(I, ':'))
-                    if dimI < sum(sizeB>1)
+                    if dimI < sum(sizeB_reduced>1)
                         error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                     end
                     for ii = 1:(dimI-1)  % Dimensions except the last one
                         if strcmp(I{ii}, ':')
-                            I{ii} = 1:sizeB(idx);
-                            tmpProd = tmpProd * sizeB(idx);
+                            I{ii} = 1:sizeB_reduced(idx);
+                            tmpProd = tmpProd * sizeB_reduced(idx);
                             idx = idx + 1;
                         elseif numel(I{ii}) > 1
-                            if numel(I{ii}) ~= sizeB(idx)
+                            if numel(I{ii}) ~= sizeB_reduced(idx)
                                 error('Unable to perform assignment because the indices on the left side are not compatible with the size of the right side.');
                             end
-                            tmpProd = tmpProd * sizeB(idx);
+                            tmpProd = tmpProd * sizeB_reduced(idx);
                             idx = idx + 1;
                         end
                     end
@@ -632,15 +642,20 @@ classdef MCProp
                 end
             end
             
-            I_isempty = cellfun(@isempty, I);
-            I_maxIndex = zeros(size(I));
-            I_maxIndex(~I_isempty) = cellfun(@(x) double(max(x)), I(~I_isempty));
+            for ii = numel(I):-1:1
+                I_isempty = isempty(I{ii});
+                if I_isempty
+                    I_maxIndex(ii) = 0;
+                else
+                    I_maxIndex(ii) = double(max(I{ii}));
+                end
+            end
 
             if any(I_isempty) && numelA == 0
-                if numel(B) <= 1
+                if numelB <= 1
                     s = I_maxIndex;
                     if numel(s) < 2
-                        if ~isempty(B)
+                        if ~isemptyB
                             s = [s zeros(1,2-numel(s))];
                         else
                             s = [ones(1,2-numel(s)) s];
@@ -660,15 +675,15 @@ classdef MCProp
             if dimI == 1
                 % Linear indexing follows some specific rules
                 
-                if ~isscalar(B) && numel(I{1}) ~= numel(B)
+                if ~isscalarB && numel(I{1}) ~= numelB
                     error('Unable to perform assignment because the left and right sides have a different number of elements.');
                 end
                 
                 % Grow vector if necessary
                 if I_maxIndex > numelA
                     if numelA == 0
-                        A = MCProp(zeros(1, I_maxIndex));
-                        if B.IsComplex
+                        A = zeros(1, I_maxIndex, 'MCProp');
+                        if isComplex
                             A = complex(A);
                         end
                     elseif isrow(A)
@@ -685,10 +700,10 @@ classdef MCProp
                 bm = MCProp.Convert2UncArray(B);
                 dest_index = MCProp.IndexMatrix(I);
 
-                if isscalar(B)
+                if isscalarB
                     am.SetSameItem1d(int32(dest_index - 1), bm.GetItem1d(0));
                 else
-                    am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numel(B)-1)));
+                    am.SetItems1d(int32(dest_index - 1), bm.GetItems1d(int32(0 : numelB-1)));
                 end
                 
                 C = MCProp.Convert2MCProp(am);
@@ -697,7 +712,7 @@ classdef MCProp
             % Or subscript indexing / partial linear indexing
             else
   
-                if dimI < ndims(A)
+                if dimI < numel(sizeA)
                     % partial linear indexing
                     if max(I{end}) > prod(sizeA(dimI:end))
                         error('Attempt to grow array along ambiguous dimension.');
@@ -705,7 +720,9 @@ classdef MCProp
                 else
                     % Ignore empty and singleton dimensions that have been
                     % indexed but do not exist anyways.
-                    I_issingleton = cellfun(@(x) all(x == 1), I);
+                    for ii = dimI:-1:1
+                        I_issingleton(ii) = all(I{ii}(:) == 1);
+                    end
                     I_lastRelevant = [find(not(I_isempty | I_issingleton), 1, 'last') 2];
                     I_lastRelevant = I_lastRelevant(1);
                     I = I(1:min(dimI, max(numel(sizeA), I_lastRelevant)));
@@ -714,15 +731,16 @@ classdef MCProp
                 end
                 
                 % Check dimensions
-                if ~isscalar(B)
-                    sizeI = cellfun(@numel, I);
-                    sizeB = size(B);
+                if ~isscalarB
+                    for ii = dimI:-1:1
+                        I_numel(ii) = numel(I{ii});
+                    end
                     
-                    sizeI_reduced = sizeI(sizeI > 1);
+                    sizeI_reduced = I_numel(I_numel > 1);
                     sizeB_reduced = sizeB(sizeB > 1);
                     if numel(sizeI_reduced) ~= numel(sizeB_reduced) || any(sizeI_reduced ~= sizeB_reduced)
                         error('Unable to perform assignment because the size of the left side is %s and the size of the right side is %s.', ...
-                        strjoin(string(sizeI), '-by-'), ...
+                        strjoin(string(I_numel), '-by-'), ...
                         strjoin(string(sizeB), '-by-'));
                     end
                     
@@ -735,7 +753,7 @@ classdef MCProp
                 sA_nI = [sizeA(1 : (dimI-1)), prod(sizeA(dimI:end))]; % size of A, when using the same number of dimensions as nI;
                 if any(I_maxIndex > sA_nI)
                     A2 = MCProp(zeros(max(I_maxIndex, sA_nI)));
-                    if B.IsComplex
+                    if isComplex
                         A2 = complex(A2);
                     end
                     if numel(A) == 0
@@ -758,10 +776,10 @@ classdef MCProp
                 bm = MCProp.Convert2UncArray(B);
                 dest_index = MCProp.IndexMatrix(I);
 
-                if isscalar(B)
+                if isscalarB
                     am.SetSameItemNd(int32(dest_index - 1), bm.GetItem1d(0));
                 else
-                    src_subs = arrayfun(@(x) 1:x, size(B), 'UniformOutput', false);
+                    src_subs = arrayfun(@(x) 1:x, sizeB, 'UniformOutput', false);
                     src_index  = MCProp.IndexMatrix(src_subs);
 
                     am.SetItemsNd(int32(dest_index - 1), bm.GetItemsNd(int32(src_index - 1)));


### PR DESCRIPTION
In my test case (OSM calibration with deembedding) these changes reduced the runtime of subsasgn by about 35%.

For me, all tests in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests pass.

- Replaced calls to cellfun() with loops.
- Cached size/numel/isempty/isscalar complex
- Renamed `sizeI` to `I_numel` to prevent cofusion with cached variables.