### PR TITLE
Removed incorrect reshape operation from integrate2 and splineintegrate2.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 22.03.2022
+% Dion Timmermann PTB - 07.04.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -1761,12 +1761,10 @@ classdef DistProp
             x = double(x(:));
             y = DistProp(y);
             n = int32(n);
-            s = size(y);
             numlib = DistProp.NumLib2(y.IsComplex);
             ym = DistProp.Convert2UncArray(y);
             am = numlib.Integrate2(x, ym, n);
             a = DistProp.Convert2DistProp(am);
-            a = reshape(a, s);
         end
         function a = splineintegrate(x, y, varargin)
             x = double(x(:));
@@ -1782,13 +1780,11 @@ classdef DistProp
         function a = splineintegrate2(x, y, varargin)
             x = double(x(:));
             y = DistProp(y);
-            s = size(y);
             [y, sb, sv, eb, ev] = SplineOptArgs(y, varargin{:});
             numlib = DistProp.NumLib2(y.IsComplex);
             ym = DistProp.Convert2UncArray(y);
             am = numlib.SplineIntegrate2(x, ym, sb, sv, eb, ev);
             a = DistProp.Convert2DistProp(am);
-            a = reshape(a, s);
          end
         function p = polyfit(x,y,n)
             x = DistProp(x);

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 22.03.2022
+% Dion Timmermann PTB - 07.04.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -1761,12 +1761,10 @@ classdef LinProp
             x = double(x(:));
             y = LinProp(y);
             n = int32(n);
-            s = size(y);
             numlib = LinProp.NumLib2(y.IsComplex);
             ym = LinProp.Convert2UncArray(y);
             am = numlib.Integrate2(x, ym, n);
             a = LinProp.Convert2LinProp(am);
-            a = reshape(a, s);
         end
         function a = splineintegrate(x, y, varargin)
             x = double(x(:));
@@ -1782,13 +1780,11 @@ classdef LinProp
         function a = splineintegrate2(x, y, varargin)
             x = double(x(:));
             y = LinProp(y);
-            s = size(y);
             [y, sb, sv, eb, ev] = SplineOptArgs(y, varargin{:});
             numlib = LinProp.NumLib2(y.IsComplex);
             ym = LinProp.Convert2UncArray(y);
             am = numlib.SplineIntegrate2(x, ym, sb, sv, eb, ev);
             a = LinProp.Convert2LinProp(am);
-            a = reshape(a, s);
          end
         function p = polyfit(x,y,n)
             x = LinProp(x);

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 22.03.2022
+% Dion Timmermann PTB - 07.04.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -1761,12 +1761,10 @@ classdef MCProp
             x = double(x(:));
             y = MCProp(y);
             n = int32(n);
-            s = size(y);
             numlib = MCProp.NumLib2(y.IsComplex);
             ym = MCProp.Convert2UncArray(y);
             am = numlib.Integrate2(x, ym, n);
             a = MCProp.Convert2MCProp(am);
-            a = reshape(a, s);
         end
         function a = splineintegrate(x, y, varargin)
             x = double(x(:));
@@ -1782,13 +1780,11 @@ classdef MCProp
         function a = splineintegrate2(x, y, varargin)
             x = double(x(:));
             y = MCProp(y);
-            s = size(y);
             [y, sb, sv, eb, ev] = SplineOptArgs(y, varargin{:});
             numlib = MCProp.NumLib2(y.IsComplex);
             ym = MCProp.Convert2UncArray(y);
             am = numlib.SplineIntegrate2(x, ym, sb, sv, eb, ev);
             a = MCProp.Convert2MCProp(am);
-            a = reshape(a, s);
          end
         function p = polyfit(x,y,n)
             x = MCProp(x);


### PR DESCRIPTION
As mentioned in #51, integrate2 and splineintegrate2 only return a scalar. Probably due to copy-and-paste, both functions tried to reshape the output to the same size as y (as do integrate and splineintegrate), which caused the methods to always throw an error.