### PR TITLE
Fixed a rare bug in horzcat() and vertcat(), added cat().

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 07.04.2022
+% Dion Timmermann PTB - 27.04.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -1001,29 +1001,32 @@ classdef DistProp
                 end
             end
         end
-        function c = horzcat(a, varargin)
+        function c = cat(dim, a, varargin)
             
-            catDim = 2;
             c = a;
                 
             if numel(varargin) > 0
                 ndimsA = ndims(a);
-                if any(cellfun(@ndims, varargin) ~= ndimsA)
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                checkDims = 1:ndimsA;
-                checkDims(catDim) = [];
-                sizeAExceptCatDim = size(a, checkDims);
-                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
-                    error('Dimensions of arrays being concatenated are not consistent.');
+                sizeA = size(a);
+                sizeVararginElements = cell(1, numel(varargin));
+                for ii = 1:numel(varargin)
+                    if ndims(varargin{ii}) ~= ndimsA
+                        error('Dimensions of arrays being concatenated are not consistent.');
+                    end
+                    sizeVararginElements{ii} = size(varargin{ii});
+                    for kk = 1:ndimsA
+                        if kk ~= dim && sizeA(kk) ~= sizeVararginElements{ii}(kk)
+                            error('Dimensions of arrays being concatenated are not consistent.');
+                        end
+                    end
                 end
                 
-                sizeAInCatDim = size(a, catDim);
+                sizeAInCatDim = sizeA(dim);
                 for ii = 1:numel(varargin)
                     subs = cell(1, ndimsA);
                     subs(:) = {':'};
-                    sizeVararginInCatDim = size(varargin{ii}, catDim);
-                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    sizeVararginInCatDim = sizeVararginElements{ii}(dim);
+                    subs{dim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
                     c = subsasgn(c, substruct('()', subs), varargin{ii});
                     
                     sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
@@ -1031,35 +1034,11 @@ classdef DistProp
                 
             end
         end
+        function c = horzcat(a, varargin)
+            c = cat(2, a, varargin{:});
+        end
         function c = vertcat(a, varargin)
-            
-            catDim = 1;
-            c = a;
-                
-            if numel(varargin) > 0
-                ndimsA = ndims(a);
-                if any(cellfun(@ndims, varargin) ~= ndimsA)
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                checkDims = 1:ndimsA;
-                checkDims(catDim) = [];
-                sizeAExceptCatDim = size(a, checkDims);
-                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                
-                sizeAInCatDim = size(a, catDim);
-                for ii = 1:numel(varargin)
-                    subs = cell(1, ndimsA);
-                    subs(:) = {':'};
-                    sizeVararginInCatDim = size(varargin{ii}, catDim);
-                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
-                    c = subsasgn(c, substruct('()', subs), varargin{ii});
-                    
-                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
-                end
-                
-            end
+            c = cat(1, a, varargin{:});
         end
         function d = get.Value(obj)
             d = get_value(obj);

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 07.04.2022
+% Dion Timmermann PTB - 27.04.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -1001,29 +1001,32 @@ classdef LinProp
                 end
             end
         end
-        function c = horzcat(a, varargin)
+        function c = cat(dim, a, varargin)
             
-            catDim = 2;
             c = a;
                 
             if numel(varargin) > 0
                 ndimsA = ndims(a);
-                if any(cellfun(@ndims, varargin) ~= ndimsA)
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                checkDims = 1:ndimsA;
-                checkDims(catDim) = [];
-                sizeAExceptCatDim = size(a, checkDims);
-                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
-                    error('Dimensions of arrays being concatenated are not consistent.');
+                sizeA = size(a);
+                sizeVararginElements = cell(1, numel(varargin));
+                for ii = 1:numel(varargin)
+                    if ndims(varargin{ii}) ~= ndimsA
+                        error('Dimensions of arrays being concatenated are not consistent.');
+                    end
+                    sizeVararginElements{ii} = size(varargin{ii});
+                    for kk = 1:ndimsA
+                        if kk ~= dim && sizeA(kk) ~= sizeVararginElements{ii}(kk)
+                            error('Dimensions of arrays being concatenated are not consistent.');
+                        end
+                    end
                 end
                 
-                sizeAInCatDim = size(a, catDim);
+                sizeAInCatDim = sizeA(dim);
                 for ii = 1:numel(varargin)
                     subs = cell(1, ndimsA);
                     subs(:) = {':'};
-                    sizeVararginInCatDim = size(varargin{ii}, catDim);
-                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    sizeVararginInCatDim = sizeVararginElements{ii}(dim);
+                    subs{dim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
                     c = subsasgn(c, substruct('()', subs), varargin{ii});
                     
                     sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
@@ -1031,35 +1034,11 @@ classdef LinProp
                 
             end
         end
+        function c = horzcat(a, varargin)
+            c = cat(2, a, varargin{:});
+        end
         function c = vertcat(a, varargin)
-            
-            catDim = 1;
-            c = a;
-                
-            if numel(varargin) > 0
-                ndimsA = ndims(a);
-                if any(cellfun(@ndims, varargin) ~= ndimsA)
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                checkDims = 1:ndimsA;
-                checkDims(catDim) = [];
-                sizeAExceptCatDim = size(a, checkDims);
-                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                
-                sizeAInCatDim = size(a, catDim);
-                for ii = 1:numel(varargin)
-                    subs = cell(1, ndimsA);
-                    subs(:) = {':'};
-                    sizeVararginInCatDim = size(varargin{ii}, catDim);
-                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
-                    c = subsasgn(c, substruct('()', subs), varargin{ii});
-                    
-                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
-                end
-                
-            end
+            c = cat(1, a, varargin{:});
         end
         function d = get.Value(obj)
             d = get_value(obj);

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 07.04.2022
+% Dion Timmermann PTB - 27.04.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -1001,29 +1001,32 @@ classdef MCProp
                 end
             end
         end
-        function c = horzcat(a, varargin)
+        function c = cat(dim, a, varargin)
             
-            catDim = 2;
             c = a;
                 
             if numel(varargin) > 0
                 ndimsA = ndims(a);
-                if any(cellfun(@ndims, varargin) ~= ndimsA)
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                checkDims = 1:ndimsA;
-                checkDims(catDim) = [];
-                sizeAExceptCatDim = size(a, checkDims);
-                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
-                    error('Dimensions of arrays being concatenated are not consistent.');
+                sizeA = size(a);
+                sizeVararginElements = cell(1, numel(varargin));
+                for ii = 1:numel(varargin)
+                    if ndims(varargin{ii}) ~= ndimsA
+                        error('Dimensions of arrays being concatenated are not consistent.');
+                    end
+                    sizeVararginElements{ii} = size(varargin{ii});
+                    for kk = 1:ndimsA
+                        if kk ~= dim && sizeA(kk) ~= sizeVararginElements{ii}(kk)
+                            error('Dimensions of arrays being concatenated are not consistent.');
+                        end
+                    end
                 end
                 
-                sizeAInCatDim = size(a, catDim);
+                sizeAInCatDim = sizeA(dim);
                 for ii = 1:numel(varargin)
                     subs = cell(1, ndimsA);
                     subs(:) = {':'};
-                    sizeVararginInCatDim = size(varargin{ii}, catDim);
-                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
+                    sizeVararginInCatDim = sizeVararginElements{ii}(dim);
+                    subs{dim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
                     c = subsasgn(c, substruct('()', subs), varargin{ii});
                     
                     sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
@@ -1031,35 +1034,11 @@ classdef MCProp
                 
             end
         end
+        function c = horzcat(a, varargin)
+            c = cat(2, a, varargin{:});
+        end
         function c = vertcat(a, varargin)
-            
-            catDim = 1;
-            c = a;
-                
-            if numel(varargin) > 0
-                ndimsA = ndims(a);
-                if any(cellfun(@ndims, varargin) ~= ndimsA)
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                checkDims = 1:ndimsA;
-                checkDims(catDim) = [];
-                sizeAExceptCatDim = size(a, checkDims);
-                if any(cellfun(@(x) any(size(x, checkDims) ~= sizeAExceptCatDim), varargin))
-                    error('Dimensions of arrays being concatenated are not consistent.');
-                end
-                
-                sizeAInCatDim = size(a, catDim);
-                for ii = 1:numel(varargin)
-                    subs = cell(1, ndimsA);
-                    subs(:) = {':'};
-                    sizeVararginInCatDim = size(varargin{ii}, catDim);
-                    subs{catDim} = sizeAInCatDim+1:sizeAInCatDim+sizeVararginInCatDim;
-                    c = subsasgn(c, substruct('()', subs), varargin{ii});
-                    
-                    sizeAInCatDim = sizeAInCatDim+sizeVararginInCatDim;
-                end
-                
-            end
+            c = cat(1, a, varargin{:});
         end
         function d = get.Value(obj)
             d = get_value(obj);


### PR DESCRIPTION
This commit fixes a rare bug documented in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/commit/ac1591e1d79acc4fe4dec3ab521d1f394cee1788 . If *Prop variables were concatenated with non-*Prop variables in older versions of matlab, horzcat() and vertcat() failed as size() was called with parameters not supported for non-*Prop variables in older versions of matlab.

To prevent duplicate code segments, the cat() method was also implemented, which is now used by horzcat() and vertcat(). Tests for this new method have been added in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/commit/84d80c2fc9767805aa8068b25d7bdcb6d82b3a1f .

For me, all unit tests in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/ pass in matlab version 2021a and 2019a. The new tests added for cat in https://github.com/DionTimmermann/metas-unclib-matlab-wrapper-tests/commit/84d80c2fc9767805aa8068b25d7bdcb6d82b3a1f cause the the unit test framework to fail without the changes in this pull-request. As cat() had not been implemented for *Prop variables, matlab returned an invalid object.