### PR TITLE
Constructor with generic ids

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 27.04.2022
+% Dion Timmermann PTB - 28.04.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -238,7 +238,12 @@ classdef DistProp
                         error('Wrong type of input arguments')
                     end
                 case 5
-                    if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId') && isa(varargin{5}, 'char')
+                    if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{5}, 'char')
+                        if ischar(varargin{4}) || (isstring(varargin{4}) && numel(varargin{4}) == 1)
+                            varargin{4} = UncInputId(varargin{4});
+                        elseif ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
+                            error('Wrong type of input arguments')
+                        end
                         if numel(varargin{1}) == 1
                             obj.NetObject = Metas.UncLib.DistProp.UncNumber(varargin{1}, varargin{2}, varargin{3}, varargin{4}, sprintf(varargin{5}));
                         else

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -239,10 +239,8 @@ classdef DistProp
                     end
                 case 5
                     if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{5}, 'char')
-                        if ischar(varargin{4}) || (isstring(varargin{4}) && numel(varargin{4}) == 1)
+                        if ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
                             varargin{4} = UncInputId(varargin{4});
-                        elseif ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
-                            error('Wrong type of input arguments')
                         end
                         if numel(varargin{1}) == 1
                             obj.NetObject = Metas.UncLib.DistProp.UncNumber(varargin{1}, varargin{2}, varargin{3}, varargin{4}, sprintf(varargin{5}));

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -239,10 +239,8 @@ classdef LinProp
                     end
                 case 5
                     if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{5}, 'char')
-                        if ischar(varargin{4}) || (isstring(varargin{4}) && numel(varargin{4}) == 1)
+                        if ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
                             varargin{4} = UncInputId(varargin{4});
-                        elseif ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
-                            error('Wrong type of input arguments')
                         end
                         if numel(varargin{1}) == 1
                             obj.NetObject = Metas.UncLib.LinProp.UncNumber(varargin{1}, varargin{2}, varargin{3}, varargin{4}, sprintf(varargin{5}));

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 27.04.2022
+% Dion Timmermann PTB - 28.04.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -238,7 +238,12 @@ classdef LinProp
                         error('Wrong type of input arguments')
                     end
                 case 5
-                    if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId') && isa(varargin{5}, 'char')
+                    if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{5}, 'char')
+                        if ischar(varargin{4}) || (isstring(varargin{4}) && numel(varargin{4}) == 1)
+                            varargin{4} = UncInputId(varargin{4});
+                        elseif ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
+                            error('Wrong type of input arguments')
+                        end
                         if numel(varargin{1}) == 1
                             obj.NetObject = Metas.UncLib.LinProp.UncNumber(varargin{1}, varargin{2}, varargin{3}, varargin{4}, sprintf(varargin{5}));
                         else

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.3
 % Michael Wollensack METAS - 25.02.2022
-% Dion Timmermann PTB - 27.04.2022
+% Dion Timmermann PTB - 28.04.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -238,7 +238,12 @@ classdef MCProp
                         error('Wrong type of input arguments')
                     end
                 case 5
-                    if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId') && isa(varargin{5}, 'char')
+                    if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{5}, 'char')
+                        if ischar(varargin{4}) || (isstring(varargin{4}) && numel(varargin{4}) == 1)
+                            varargin{4} = UncInputId(varargin{4});
+                        elseif ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
+                            error('Wrong type of input arguments')
+                        end
                         if numel(varargin{1}) == 1
                             obj.NetObject = Metas.UncLib.MCProp.UncNumber(varargin{1}, varargin{2}, varargin{3}, varargin{4}, sprintf(varargin{5}));
                         else

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -239,10 +239,8 @@ classdef MCProp
                     end
                 case 5
                     if isa(varargin{1}, 'double') && isa(varargin{2}, 'double') && isa(varargin{3}, 'double') && isa(varargin{5}, 'char')
-                        if ischar(varargin{4}) || (isstring(varargin{4}) && numel(varargin{4}) == 1)
+                        if ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
                             varargin{4} = UncInputId(varargin{4});
-                        elseif ~isa(varargin{4}, 'Metas.UncLib.Core.Unc.InputId')
-                            error('Wrong type of input arguments')
                         end
                         if numel(varargin{1}) == 1
                             obj.NetObject = Metas.UncLib.MCProp.UncNumber(varargin{1}, varargin{2}, varargin{3}, varargin{4}, sprintf(varargin{5}));


### PR DESCRIPTION
This pull-request extends the `a = LinProp(value, standard_unc, idof, id, description)` constructor to also accept ids that are not of the type `Metas.UncLib.Core.Unc.InputId`. Such ids are converted using `UncInputId()`.

I would argue that passing ids as strings or numeric arrays is more "the matlab way" than first creating a .NET object and passing that to a function. .NET objects are difficult to inspect and manipulate in matlab and therefore should in my oppinion be avoided as inputs and outputs of public interfaces.