### PR TITLE
Added rad2deg and deg2rad

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.4
 % Michael Wollensack METAS - 29.04.2022
-% Dion Timmermann PTB - 28.04.2022
+% Dion Timmermann PTB - 02.05.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -1297,6 +1297,12 @@ classdef DistProp
         end
         function q = unwrap(p, varargin)
             q = p + unwrap(double(p), varargin{:}) - double(p);
+        end
+        function y = deg2rad(x)
+            y = (pi/180) .* x;
+        end
+        function y = rad2deg(x)
+            y = (180/pi) .* x;
         end
         function y = exp(x)
             y = DistProp(x.NetObject.Exp());

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.4
 % Michael Wollensack METAS - 29.04.2022
-% Dion Timmermann PTB - 28.04.2022
+% Dion Timmermann PTB - 02.05.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -1297,6 +1297,12 @@ classdef LinProp
         end
         function q = unwrap(p, varargin)
             q = p + unwrap(double(p), varargin{:}) - double(p);
+        end
+        function y = deg2rad(x)
+            y = (pi/180) .* x;
+        end
+        function y = rad2deg(x)
+            y = (180/pi) .* x;
         end
         function y = exp(x)
             y = LinProp(x.NetObject.Exp());

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.4
 % Michael Wollensack METAS - 29.04.2022
-% Dion Timmermann PTB - 28.04.2022
+% Dion Timmermann PTB - 02.05.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -1297,6 +1297,12 @@ classdef MCProp
         end
         function q = unwrap(p, varargin)
             q = p + unwrap(double(p), varargin{:}) - double(p);
+        end
+        function y = deg2rad(x)
+            y = (pi/180) .* x;
+        end
+        function y = rad2deg(x)
+            y = (180/pi) .* x;
         end
         function y = exp(x)
             y = MCProp(x.NetObject.Exp());


### PR DESCRIPTION
Both functions are available in all matlab installations, but the standard implementation throws an error if `isfloat()` fails for the input argument. Thus, both functions need to be implemented as methods of *Prop.