### PR TITLE
Made display() respect current format and removed non-ascii characters from source code.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -285,23 +285,23 @@ classdef DistProp
                 pm = sprintf(' \xB1 ');
 
                 % evalc(disp(...)) ensures the output conforms to the format setting.
-                val_real  = strtrim(evalc('disp(abs(get_value(real(obj))))'));
-                unc_real  = strtrim(evalc('disp(get_stdunc(real(obj)))'    ));
+                val_real = strtrim(evalc('disp(abs(get_value(real(obj))))'));
+                unc_real = strtrim(evalc('disp(get_stdunc(real(obj)))'));
                 sign_real = ' ';
                 if (get_value(real(obj)) < 0)
                     sign_real = '-';
                 end
 
                 if obj.IsComplex
-                    val_imag  = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
-                    unc_imag  = strtrim(evalc('disp(get_stdunc(imag(obj)))'    ));
+                    val_imag = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
+                    unc_imag = strtrim(evalc('disp(get_stdunc(imag(obj)))'));
                     sign_imag = ' + ';
                     if (get_value(imag(obj)) < 0)
                         sign_imag = ' - ';
                     end
 
                     value = [sign_real '(' val_real pm unc_real ')' ...
-                           sign_imag '(' val_imag pm unc_imag ')i'];
+                             sign_imag '(' val_imag pm unc_imag ')i'];
                 else
                     value = [sign_real '(' val_real pm unc_real ')'];
                 end

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -280,12 +280,6 @@ classdef DistProp
                 end    
             else
                 
-                if isequal(ds, 'compact')
-                    vspace = char(10); % Newline compatible with old matlab installations
-                else
-                    vspace = char([10 10]);
-                end
-
                 % The plus/minus sign coded as unicode number so this
                 % source code file is not dependent on the encoding.
                 pm = sprintf(' \xB1 ');
@@ -306,15 +300,17 @@ classdef DistProp
                         sign_imag = ' - ';
                     end
 
-                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, ...
-                        [sign_real '(' val_real pm unc_real ')' ...
-                         sign_imag '(' val_imag pm unc_imag ')i'], ...
-                        vspace);
-                else        
-                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, [sign_real '(' val_real pm unc_real ')'], ...
-                                        vspace);
+                    value = [sign_real '(' val_real pm unc_real ')' ...
+                           sign_imag '(' val_imag pm unc_imag ')i'];
+                else
+                    value = [sign_real '(' val_real pm unc_real ')'];
                 end
-                
+                     
+                if isequal(ds, 'compact')
+                    fprintf('%s =\n  %s\n', name, value);
+                else
+                    fprintf('\n%s =\n\n  %s\n\n', name, value);
+                end
             end
         end
         function o = copy(obj)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -270,16 +270,16 @@ classdef DistProp
                 % Using evalc(disp(x)) prints using the current format
                 % setting. We display all parts of the number as one vector
                 % so all are displayed as floats if one of them is a float.
-                x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
+                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end
             
             str = cell(size(obj));
             for ii = 1:numel(obj)
                 
-                val_real  = get_value(real(obj));
+                val_real = get_value(real(obj));
                 unc_real = get_stdunc(real(obj));
-                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end %#ok<SEPEX>
+                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end
                 
                 if ~obj.IsComplex
                     [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
@@ -288,7 +288,7 @@ classdef DistProp
                 else
                     val_imag = get_value(imag(obj));
                     unc_imag = get_stdunc(imag(obj));
-                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end %#ok<SEPEX>
+                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end
 
                     [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
                     

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.4
 % Michael Wollensack METAS - 10.05.2022
-% Dion Timmermann PTB - 03.05.2022
+% Dion Timmermann PTB - 18.05.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -312,19 +312,25 @@ classdef DistProp
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
+                value = get_value(obj);
+                unc = get_stdunc(obj);
+                if isreal(value) ~= isreal(unc)
+                    value = complex(value);
+                    unc = complex(unc);
+                end
                 if isequal(ds, 'compact')
-                    disp([name,'.value = '])
-                    disp(get_value(obj))
-                    disp([name,'.standard_unc = '])
-                    disp(get_stdunc(obj))
+                    disp([name,'.Value = '])
+                    disp(value)
+                    disp([name,'.StdUnc = '])
+                    disp(unc)
                 else
                     disp(' ');
-                    disp([name,'.value = '])
+                    disp([name,'.Value = '])
                     disp(' ');
-                    disp(get_value(obj))
-                    disp([name,'.standard_unc = '])
+                    disp(value)
+                    disp([name,'.StdUnc = '])
                     disp(' ');
-                    disp(get_stdunc(obj))        
+                    disp(unc)        
                 end
             else
                 if isequal(ds, 'compact')

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -267,6 +267,9 @@ classdef DistProp
             pm = sprintf(' \xB1 ');
             
             function varargout = dispParts(x)
+                % Using evalc(disp(x)) prints using the current format
+                % setting. We display all parts of the number as one vector
+                % so all are displayed as floats if one of them is a float.
                 x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.4
 % Michael Wollensack METAS - 29.04.2022
-% Dion Timmermann PTB - 02.05.2022
+% Dion Timmermann PTB - 03.05.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -262,7 +262,6 @@ classdef DistProp
         end
         function display(obj)
             name = inputname(1);
-            df = '%g'; %get(0, 'Format');
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
                 if isequal(ds, 'compact')
@@ -280,35 +279,42 @@ classdef DistProp
                     disp(get_stdunc(obj))        
                 end    
             else
-                if obj.IsComplex
-                    sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
-                    simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
-                    if (get_value(imag(obj)) < 0)
-                        s = [sreal ' - ' simag 'i'];
-                    else
-                        s = [sreal ' + ' simag 'i'];
-                    end
-                else        
-                    s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' ± ' num2str(get_stdunc(obj), df) ')'];
-                end    
-                if (get_value(real(obj)) < 0)
-                    s = ['  -' s];
-                else
-                    s = ['   ' s];
-                end
+                
                 if isequal(ds, 'compact')
-                    disp([name,' = '])
-                    disp(s)
+                    vspace = char(10); % Newline compatible with old matlab installations
                 else
-                    disp(' ');
-                    disp([name,' = '])
-                    disp(' ');
-                    disp(s)
-                    disp(' ');
-                end    
+                    vspace = char([10 10]);
+                end
+
+                % The plus/minus sign coded as unicode number so this
+                % source code file is not dependent on the encoding.
+                pm = sprintf(' \xB1 ');
+
+                % evalc(disp(...)) ensures the output conforms to the format setting.
+                val_real  = strtrim(evalc('disp(abs(get_value(real(obj))))'));
+                unc_real  = strtrim(evalc('disp(get_stdunc(real(obj)))'    ));
+                sign_real = ' ';
+                if (get_value(real(obj)) < 0)
+                    sign_real = '-';
+                end
+
+                if obj.IsComplex
+                    val_imag  = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
+                    unc_imag  = strtrim(evalc('disp(get_stdunc(imag(obj)))'    ));
+                    sign_imag = ' + ';
+                    if (get_value(imag(obj)) < 0)
+                        sign_imag = ' - ';
+                    end
+
+                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, ...
+                        [sign_real '(' val_real pm unc_real ')' ...
+                         sign_imag '(' val_imag pm unc_imag ')i'], ...
+                        vspace);
+                else        
+                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, [sign_real '(' val_real pm unc_real ')'], ...
+                                        vspace);
+                end
+                
             end
         end
         function o = copy(obj)

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -267,7 +267,7 @@ classdef DistProp
             pm = sprintf(' \xB1 ');
             
             function varargout = dispParts(x)
-                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
+                x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end
             
@@ -276,10 +276,7 @@ classdef DistProp
                 
                 val_real  = get_value(real(obj));
                 unc_real = get_stdunc(real(obj));
-                sign_real = ' ';
-                if val_real < 0
-                    sign_real = '-';
-                end
+                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end %#ok<SEPEX>
                 
                 if ~obj.IsComplex
                     [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
@@ -288,10 +285,7 @@ classdef DistProp
                 else
                     val_imag = get_value(imag(obj));
                     unc_imag = get_stdunc(imag(obj));
-                    sign_imag = ' + ';
-                    if val_imag < 0
-                        sign_imag = ' - ';
-                    end
+                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end %#ok<SEPEX>
 
                     [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
                     

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.4
 % Michael Wollensack METAS - 29.04.2022
-% Dion Timmermann PTB - 02.05.2022
+% Dion Timmermann PTB - 03.05.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -262,7 +262,6 @@ classdef LinProp
         end
         function display(obj)
             name = inputname(1);
-            df = '%g'; %get(0, 'Format');
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
                 if isequal(ds, 'compact')
@@ -280,35 +279,42 @@ classdef LinProp
                     disp(get_stdunc(obj))        
                 end    
             else
-                if obj.IsComplex
-                    sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
-                    simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
-                    if (get_value(imag(obj)) < 0)
-                        s = [sreal ' - ' simag 'i'];
-                    else
-                        s = [sreal ' + ' simag 'i'];
-                    end
-                else        
-                    s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' ± ' num2str(get_stdunc(obj), df) ')'];
-                end    
-                if (get_value(real(obj)) < 0)
-                    s = ['  -' s];
-                else
-                    s = ['   ' s];
-                end
+                
                 if isequal(ds, 'compact')
-                    disp([name,' = '])
-                    disp(s)
+                    vspace = char(10); % Newline compatible with old matlab installations
                 else
-                    disp(' ');
-                    disp([name,' = '])
-                    disp(' ');
-                    disp(s)
-                    disp(' ');
-                end    
+                    vspace = char([10 10]);
+                end
+
+                % The plus/minus sign coded as unicode number so this
+                % source code file is not dependent on the encoding.
+                pm = sprintf(' \xB1 ');
+
+                % evalc(disp(...)) ensures the output conforms to the format setting.
+                val_real  = strtrim(evalc('disp(abs(get_value(real(obj))))'));
+                unc_real  = strtrim(evalc('disp(get_stdunc(real(obj)))'    ));
+                sign_real = ' ';
+                if (get_value(real(obj)) < 0)
+                    sign_real = '-';
+                end
+
+                if obj.IsComplex
+                    val_imag  = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
+                    unc_imag  = strtrim(evalc('disp(get_stdunc(imag(obj)))'    ));
+                    sign_imag = ' + ';
+                    if (get_value(imag(obj)) < 0)
+                        sign_imag = ' - ';
+                    end
+
+                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, ...
+                        [sign_real '(' val_real pm unc_real ')' ...
+                         sign_imag '(' val_imag pm unc_imag ')i'], ...
+                        vspace);
+                else        
+                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, [sign_real '(' val_real pm unc_real ')'], ...
+                                        vspace);
+                end
+                
             end
         end
         function o = copy(obj)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.4
 % Michael Wollensack METAS - 10.05.2022
-% Dion Timmermann PTB - 03.05.2022
+% Dion Timmermann PTB - 18.05.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -312,19 +312,25 @@ classdef LinProp
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
+                value = get_value(obj);
+                unc = get_stdunc(obj);
+                if isreal(value) ~= isreal(unc)
+                    value = complex(value);
+                    unc = complex(unc);
+                end
                 if isequal(ds, 'compact')
-                    disp([name,'.value = '])
-                    disp(get_value(obj))
-                    disp([name,'.standard_unc = '])
-                    disp(get_stdunc(obj))
+                    disp([name,'.Value = '])
+                    disp(value)
+                    disp([name,'.StdUnc = '])
+                    disp(unc)
                 else
                     disp(' ');
-                    disp([name,'.value = '])
+                    disp([name,'.Value = '])
                     disp(' ');
-                    disp(get_value(obj))
-                    disp([name,'.standard_unc = '])
+                    disp(value)
+                    disp([name,'.StdUnc = '])
                     disp(' ');
-                    disp(get_stdunc(obj))        
+                    disp(unc)        
                 end
             else
                 if isequal(ds, 'compact')

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -267,6 +267,9 @@ classdef LinProp
             pm = sprintf(' \xB1 ');
             
             function varargout = dispParts(x)
+                % Using evalc(disp(x)) prints using the current format
+                % setting. We display all parts of the number as one vector
+                % so all are displayed as floats if one of them is a float.
                 x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -280,12 +280,6 @@ classdef LinProp
                 end    
             else
                 
-                if isequal(ds, 'compact')
-                    vspace = char(10); % Newline compatible with old matlab installations
-                else
-                    vspace = char([10 10]);
-                end
-
                 % The plus/minus sign coded as unicode number so this
                 % source code file is not dependent on the encoding.
                 pm = sprintf(' \xB1 ');
@@ -306,15 +300,17 @@ classdef LinProp
                         sign_imag = ' - ';
                     end
 
-                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, ...
-                        [sign_real '(' val_real pm unc_real ')' ...
-                         sign_imag '(' val_imag pm unc_imag ')i'], ...
-                        vspace);
-                else        
-                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, [sign_real '(' val_real pm unc_real ')'], ...
-                                        vspace);
+                    value = [sign_real '(' val_real pm unc_real ')' ...
+                           sign_imag '(' val_imag pm unc_imag ')i'];
+                else
+                    value = [sign_real '(' val_real pm unc_real ')'];
                 end
-                
+                     
+                if isequal(ds, 'compact')
+                    fprintf('%s =\n  %s\n', name, value);
+                else
+                    fprintf('\n%s =\n\n  %s\n\n', name, value);
+                end
             end
         end
         function o = copy(obj)

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -267,7 +267,7 @@ classdef LinProp
             pm = sprintf(' \xB1 ');
             
             function varargout = dispParts(x)
-                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
+                x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end
             
@@ -276,10 +276,7 @@ classdef LinProp
                 
                 val_real  = get_value(real(obj));
                 unc_real = get_stdunc(real(obj));
-                sign_real = ' ';
-                if val_real < 0
-                    sign_real = '-';
-                end
+                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end %#ok<SEPEX>
                 
                 if ~obj.IsComplex
                     [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
@@ -288,10 +285,7 @@ classdef LinProp
                 else
                     val_imag = get_value(imag(obj));
                     unc_imag = get_stdunc(imag(obj));
-                    sign_imag = ' + ';
-                    if val_imag < 0
-                        sign_imag = ' - ';
-                    end
+                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end %#ok<SEPEX>
 
                     [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
                     

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -285,23 +285,23 @@ classdef LinProp
                 pm = sprintf(' \xB1 ');
 
                 % evalc(disp(...)) ensures the output conforms to the format setting.
-                val_real  = strtrim(evalc('disp(abs(get_value(real(obj))))'));
-                unc_real  = strtrim(evalc('disp(get_stdunc(real(obj)))'    ));
+                val_real = strtrim(evalc('disp(abs(get_value(real(obj))))'));
+                unc_real = strtrim(evalc('disp(get_stdunc(real(obj)))'));
                 sign_real = ' ';
                 if (get_value(real(obj)) < 0)
                     sign_real = '-';
                 end
 
                 if obj.IsComplex
-                    val_imag  = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
-                    unc_imag  = strtrim(evalc('disp(get_stdunc(imag(obj)))'    ));
+                    val_imag = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
+                    unc_imag = strtrim(evalc('disp(get_stdunc(imag(obj)))'));
                     sign_imag = ' + ';
                     if (get_value(imag(obj)) < 0)
                         sign_imag = ' - ';
                     end
 
                     value = [sign_real '(' val_real pm unc_real ')' ...
-                           sign_imag '(' val_imag pm unc_imag ')i'];
+                             sign_imag '(' val_imag pm unc_imag ')i'];
                 else
                     value = [sign_real '(' val_real pm unc_real ')'];
                 end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -270,16 +270,16 @@ classdef LinProp
                 % Using evalc(disp(x)) prints using the current format
                 % setting. We display all parts of the number as one vector
                 % so all are displayed as floats if one of them is a float.
-                x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
+                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end
             
             str = cell(size(obj));
             for ii = 1:numel(obj)
                 
-                val_real  = get_value(real(obj));
+                val_real = get_value(real(obj));
                 unc_real = get_stdunc(real(obj));
-                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end %#ok<SEPEX>
+                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end
                 
                 if ~obj.IsComplex
                     [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
@@ -288,7 +288,7 @@ classdef LinProp
                 else
                     val_imag = get_value(imag(obj));
                     unc_imag = get_stdunc(imag(obj));
-                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end %#ok<SEPEX>
+                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end
 
                     [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
                     

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -260,6 +260,54 @@ classdef LinProp
                 end
             end 
         end
+        function str = string(obj)
+            
+            % The plus/minus sign coded as unicode number so this
+            % source code file is not dependent on the encoding.
+            pm = sprintf(' \xB1 ');
+            
+            function varargout = dispParts(x)
+                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
+                varargout = strsplit(strtrim(evalc('disp(x)')));
+            end
+            
+            str = cell(size(obj));
+            for ii = 1:numel(obj)
+                
+                val_real  = get_value(real(obj));
+                unc_real = get_stdunc(real(obj));
+                sign_real = ' ';
+                if val_real < 0
+                    sign_real = '-';
+                end
+                
+                if ~obj.IsComplex
+                    [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
+                    
+                    str{ii} = [sign_real '(' val_real pm unc_real ')'];
+                else
+                    val_imag = get_value(imag(obj));
+                    unc_imag = get_stdunc(imag(obj));
+                    sign_imag = ' + ';
+                    if val_imag < 0
+                        sign_imag = ' - ';
+                    end
+
+                    [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
+                    
+                    str{ii} = [sign_real '(' val_real pm unc_real ')' ...
+                               sign_imag '(' val_imag pm unc_imag ')i'];
+                end
+                
+            end
+            
+            % Strings and the string() function were introduced in Matalb
+            % 2016b (version 9.1). Return the cellstr for older versions.
+            if ~verLessThan('matlab', '9.1')
+                str = string(str);
+            end
+            
+        end
         function display(obj)
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
@@ -277,39 +325,12 @@ classdef LinProp
                     disp([name,'.standard_unc = '])
                     disp(' ');
                     disp(get_stdunc(obj))        
-                end    
+                end
             else
-                
-                % The plus/minus sign coded as unicode number so this
-                % source code file is not dependent on the encoding.
-                pm = sprintf(' \xB1 ');
-
-                % evalc(disp(...)) ensures the output conforms to the format setting.
-                val_real = strtrim(evalc('disp(abs(get_value(real(obj))))'));
-                unc_real = strtrim(evalc('disp(get_stdunc(real(obj)))'));
-                sign_real = ' ';
-                if (get_value(real(obj)) < 0)
-                    sign_real = '-';
-                end
-
-                if obj.IsComplex
-                    val_imag = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
-                    unc_imag = strtrim(evalc('disp(get_stdunc(imag(obj)))'));
-                    sign_imag = ' + ';
-                    if (get_value(imag(obj)) < 0)
-                        sign_imag = ' - ';
-                    end
-
-                    value = [sign_real '(' val_real pm unc_real ')' ...
-                             sign_imag '(' val_imag pm unc_imag ')i'];
-                else
-                    value = [sign_real '(' val_real pm unc_real ')'];
-                end
-                     
                 if isequal(ds, 'compact')
-                    fprintf('%s =\n  %s\n', name, value);
+                    fprintf('%s =\n  %s\n', name, char(string(obj)));
                 else
-                    fprintf('\n%s =\n\n  %s\n\n', name, value);
+                    fprintf('\n%s =\n\n  %s\n\n', name, char(string(obj)));
                 end
             end
         end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -267,6 +267,9 @@ classdef MCProp
             pm = sprintf(' \xB1 ');
             
             function varargout = dispParts(x)
+                % Using evalc(disp(x)) prints using the current format
+                % setting. We display all parts of the number as one vector
+                % so all are displayed as floats if one of them is a float.
                 x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.4
 % Michael Wollensack METAS - 29.04.2022
-% Dion Timmermann PTB - 02.05.2022
+% Dion Timmermann PTB - 03.05.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -262,7 +262,6 @@ classdef MCProp
         end
         function display(obj)
             name = inputname(1);
-            df = '%g'; %get(0, 'Format');
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
                 if isequal(ds, 'compact')
@@ -280,35 +279,42 @@ classdef MCProp
                     disp(get_stdunc(obj))        
                 end    
             else
-                if obj.IsComplex
-                    sreal = ['(' num2str(abs(get_value(real(obj))), df) ...
-                             ' ± ' num2str(get_stdunc(real(obj)), df) ')'];       
-                    simag = ['(' num2str(abs(get_value(imag(obj))), df) ...
-                             ' ± ' num2str(get_stdunc(imag(obj)), df) ')'];
-                    if (get_value(imag(obj)) < 0)
-                        s = [sreal ' - ' simag 'i'];
-                    else
-                        s = [sreal ' + ' simag 'i'];
-                    end
-                else        
-                    s = ['(' num2str(abs(get_value(obj)), df) ...
-                         ' ± ' num2str(get_stdunc(obj), df) ')'];
-                end    
-                if (get_value(real(obj)) < 0)
-                    s = ['  -' s];
-                else
-                    s = ['   ' s];
-                end
+                
                 if isequal(ds, 'compact')
-                    disp([name,' = '])
-                    disp(s)
+                    vspace = char(10); % Newline compatible with old matlab installations
                 else
-                    disp(' ');
-                    disp([name,' = '])
-                    disp(' ');
-                    disp(s)
-                    disp(' ');
-                end    
+                    vspace = char([10 10]);
+                end
+
+                % The plus/minus sign coded as unicode number so this
+                % source code file is not dependent on the encoding.
+                pm = sprintf(' \xB1 ');
+
+                % evalc(disp(...)) ensures the output conforms to the format setting.
+                val_real  = strtrim(evalc('disp(abs(get_value(real(obj))))'));
+                unc_real  = strtrim(evalc('disp(get_stdunc(real(obj)))'    ));
+                sign_real = ' ';
+                if (get_value(real(obj)) < 0)
+                    sign_real = '-';
+                end
+
+                if obj.IsComplex
+                    val_imag  = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
+                    unc_imag  = strtrim(evalc('disp(get_stdunc(imag(obj)))'    ));
+                    sign_imag = ' + ';
+                    if (get_value(imag(obj)) < 0)
+                        sign_imag = ' - ';
+                    end
+
+                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, ...
+                        [sign_real '(' val_real pm unc_real ')' ...
+                         sign_imag '(' val_imag pm unc_imag ')i'], ...
+                        vspace);
+                else        
+                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, [sign_real '(' val_real pm unc_real ')'], ...
+                                        vspace);
+                end
+                
             end
         end
         function o = copy(obj)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -285,23 +285,23 @@ classdef MCProp
                 pm = sprintf(' \xB1 ');
 
                 % evalc(disp(...)) ensures the output conforms to the format setting.
-                val_real  = strtrim(evalc('disp(abs(get_value(real(obj))))'));
-                unc_real  = strtrim(evalc('disp(get_stdunc(real(obj)))'    ));
+                val_real = strtrim(evalc('disp(abs(get_value(real(obj))))'));
+                unc_real = strtrim(evalc('disp(get_stdunc(real(obj)))'));
                 sign_real = ' ';
                 if (get_value(real(obj)) < 0)
                     sign_real = '-';
                 end
 
                 if obj.IsComplex
-                    val_imag  = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
-                    unc_imag  = strtrim(evalc('disp(get_stdunc(imag(obj)))'    ));
+                    val_imag = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
+                    unc_imag = strtrim(evalc('disp(get_stdunc(imag(obj)))'));
                     sign_imag = ' + ';
                     if (get_value(imag(obj)) < 0)
                         sign_imag = ' - ';
                     end
 
                     value = [sign_real '(' val_real pm unc_real ')' ...
-                           sign_imag '(' val_imag pm unc_imag ')i'];
+                             sign_imag '(' val_imag pm unc_imag ')i'];
                 else
                     value = [sign_real '(' val_real pm unc_real ')'];
                 end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -267,7 +267,7 @@ classdef MCProp
             pm = sprintf(' \xB1 ');
             
             function varargout = dispParts(x)
-                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
+                x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end
             
@@ -276,10 +276,7 @@ classdef MCProp
                 
                 val_real  = get_value(real(obj));
                 unc_real = get_stdunc(real(obj));
-                sign_real = ' ';
-                if val_real < 0
-                    sign_real = '-';
-                end
+                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end %#ok<SEPEX>
                 
                 if ~obj.IsComplex
                     [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
@@ -288,10 +285,7 @@ classdef MCProp
                 else
                     val_imag = get_value(imag(obj));
                     unc_imag = get_stdunc(imag(obj));
-                    sign_imag = ' + ';
-                    if val_imag < 0
-                        sign_imag = ' - ';
-                    end
+                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end %#ok<SEPEX>
 
                     [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
                     

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -280,12 +280,6 @@ classdef MCProp
                 end    
             else
                 
-                if isequal(ds, 'compact')
-                    vspace = char(10); % Newline compatible with old matlab installations
-                else
-                    vspace = char([10 10]);
-                end
-
                 % The plus/minus sign coded as unicode number so this
                 % source code file is not dependent on the encoding.
                 pm = sprintf(' \xB1 ');
@@ -306,15 +300,17 @@ classdef MCProp
                         sign_imag = ' - ';
                     end
 
-                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, ...
-                        [sign_real '(' val_real pm unc_real ')' ...
-                         sign_imag '(' val_imag pm unc_imag ')i'], ...
-                        vspace);
-                else        
-                    fprintf('%s%s =%s  %s%s', vspace(1:end-1), name, vspace, [sign_real '(' val_real pm unc_real ')'], ...
-                                        vspace);
+                    value = [sign_real '(' val_real pm unc_real ')' ...
+                           sign_imag '(' val_imag pm unc_imag ')i'];
+                else
+                    value = [sign_real '(' val_real pm unc_real ')'];
                 end
-                
+                     
+                if isequal(ds, 'compact')
+                    fprintf('%s =\n  %s\n', name, value);
+                else
+                    fprintf('\n%s =\n\n  %s\n\n', name, value);
+                end
             end
         end
         function o = copy(obj)

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -270,16 +270,16 @@ classdef MCProp
                 % Using evalc(disp(x)) prints using the current format
                 % setting. We display all parts of the number as one vector
                 % so all are displayed as floats if one of them is a float.
-                x = reshape(x, [], 1); %#ok<NASGU> % Enforce a column vector so disp does not produce 'Column x' statements.
+                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
                 varargout = strsplit(strtrim(evalc('disp(x)')));
             end
             
             str = cell(size(obj));
             for ii = 1:numel(obj)
                 
-                val_real  = get_value(real(obj));
+                val_real = get_value(real(obj));
                 unc_real = get_stdunc(real(obj));
-                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end %#ok<SEPEX>
+                if (val_real < 0) sign_real = '-'; else sign_real = ' '; end
                 
                 if ~obj.IsComplex
                     [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
@@ -288,7 +288,7 @@ classdef MCProp
                 else
                     val_imag = get_value(imag(obj));
                     unc_imag = get_stdunc(imag(obj));
-                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end %#ok<SEPEX>
+                    if (val_imag < 0) sign_imag = ' - '; else sign_imag = ' + '; end
 
                     [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
                     

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.4
 % Michael Wollensack METAS - 10.05.2022
-% Dion Timmermann PTB - 03.05.2022
+% Dion Timmermann PTB - 18.05.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -312,19 +312,25 @@ classdef MCProp
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
+                value = get_value(obj);
+                unc = get_stdunc(obj);
+                if isreal(value) ~= isreal(unc)
+                    value = complex(value);
+                    unc = complex(unc);
+                end
                 if isequal(ds, 'compact')
-                    disp([name,'.value = '])
-                    disp(get_value(obj))
-                    disp([name,'.standard_unc = '])
-                    disp(get_stdunc(obj))
+                    disp([name,'.Value = '])
+                    disp(value)
+                    disp([name,'.StdUnc = '])
+                    disp(unc)
                 else
                     disp(' ');
-                    disp([name,'.value = '])
+                    disp([name,'.Value = '])
                     disp(' ');
-                    disp(get_value(obj))
-                    disp([name,'.standard_unc = '])
+                    disp(value)
+                    disp([name,'.StdUnc = '])
                     disp(' ');
-                    disp(get_stdunc(obj))        
+                    disp(unc)        
                 end
             else
                 if isequal(ds, 'compact')

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -260,6 +260,54 @@ classdef MCProp
                 end
             end 
         end
+        function str = string(obj)
+            
+            % The plus/minus sign coded as unicode number so this
+            % source code file is not dependent on the encoding.
+            pm = sprintf(' \xB1 ');
+            
+            function varargout = dispParts(x)
+                x = reshape(x, [], 1); % Enforce a column vector so disp does not produce 'Column x' statements.
+                varargout = strsplit(strtrim(evalc('disp(x)')));
+            end
+            
+            str = cell(size(obj));
+            for ii = 1:numel(obj)
+                
+                val_real  = get_value(real(obj));
+                unc_real = get_stdunc(real(obj));
+                sign_real = ' ';
+                if val_real < 0
+                    sign_real = '-';
+                end
+                
+                if ~obj.IsComplex
+                    [val_real, unc_real] = dispParts([abs(val_real), unc_real]);
+                    
+                    str{ii} = [sign_real '(' val_real pm unc_real ')'];
+                else
+                    val_imag = get_value(imag(obj));
+                    unc_imag = get_stdunc(imag(obj));
+                    sign_imag = ' + ';
+                    if val_imag < 0
+                        sign_imag = ' - ';
+                    end
+
+                    [val_real, unc_real, val_imag, unc_imag] = dispParts([abs(val_real), unc_real, abs(val_imag), unc_imag]);
+                    
+                    str{ii} = [sign_real '(' val_real pm unc_real ')' ...
+                               sign_imag '(' val_imag pm unc_imag ')i'];
+                end
+                
+            end
+            
+            % Strings and the string() function were introduced in Matalb
+            % 2016b (version 9.1). Return the cellstr for older versions.
+            if ~verLessThan('matlab', '9.1')
+                str = string(str);
+            end
+            
+        end
         function display(obj)
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
@@ -277,39 +325,12 @@ classdef MCProp
                     disp([name,'.standard_unc = '])
                     disp(' ');
                     disp(get_stdunc(obj))        
-                end    
+                end
             else
-                
-                % The plus/minus sign coded as unicode number so this
-                % source code file is not dependent on the encoding.
-                pm = sprintf(' \xB1 ');
-
-                % evalc(disp(...)) ensures the output conforms to the format setting.
-                val_real = strtrim(evalc('disp(abs(get_value(real(obj))))'));
-                unc_real = strtrim(evalc('disp(get_stdunc(real(obj)))'));
-                sign_real = ' ';
-                if (get_value(real(obj)) < 0)
-                    sign_real = '-';
-                end
-
-                if obj.IsComplex
-                    val_imag = strtrim(evalc('disp(abs(get_value(imag(obj))))'));
-                    unc_imag = strtrim(evalc('disp(get_stdunc(imag(obj)))'));
-                    sign_imag = ' + ';
-                    if (get_value(imag(obj)) < 0)
-                        sign_imag = ' - ';
-                    end
-
-                    value = [sign_real '(' val_real pm unc_real ')' ...
-                             sign_imag '(' val_imag pm unc_imag ')i'];
-                else
-                    value = [sign_real '(' val_real pm unc_real ')'];
-                end
-                     
                 if isequal(ds, 'compact')
-                    fprintf('%s =\n  %s\n', name, value);
+                    fprintf('%s =\n  %s\n', name, char(string(obj)));
                 else
-                    fprintf('\n%s =\n\n  %s\n\n', name, value);
+                    fprintf('\n%s =\n\n  %s\n\n', name, char(string(obj)));
                 end
             end
         end


### PR DESCRIPTION
This basically is a backport of 2 improvements from #51 . 

Based on the line `df = '%g'; %get(0, 'Format');` it seems that `display()` was intended to respect the current format setting, i.e. behave differently for `format long` and `format short`. This behaviour is implemented here using `strtrim(evalc('disp(...)'))`. 

Additionally, the source code files now do not include the plus/minus character anymore, but instead use `pm = sprintf(' \xB1 ')`. (For me `_Copy_LinProp_to_DistProp_and_MCProp.cmd` always messed up the encoding.)

I have tested these changes with MATLAB 2015a and MATLAB 2021a.