### PR TITLE
Improved page names of properties in `display()` for variables with more than 2 dimensions.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -299,7 +299,13 @@ classdef DistProp
         function display(obj)
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
-            if obj.IsArray
+            if isempty(obj)
+                if isequal(ds, 'compact')
+                    fprintf('%s =\n     []\n', name);
+                else
+                    fprintf('\n%s =\n\n     []\n\n', name);
+                end
+            elseif obj.IsArray
                 value = get_value(obj);
                 unc = get_stdunc(obj);
                 dispAsPages([name '.Value'], value, isequal(ds, 'loose'));

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -2205,7 +2205,7 @@ function dispAsPages(name, value, isLoose)
         [page_subscripts{:}] = ind2sub(size_residual,ii);
 
         if ~isempty(size_residual)
-            page_name = sprintf('%s(:,:,%s)', name, strrep(num2str(cell2mat(page_subscripts)), '  ', ','));
+            page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
 
         if (isLoose && ii==1); disp(' '); end

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -302,10 +302,6 @@ classdef DistProp
             if obj.IsArray
                 value = get_value(obj);
                 unc = get_stdunc(obj);
-                if isreal(value) ~= isreal(unc)
-                    value = complex(value);
-                    unc = complex(unc);
-                end
                 dispAsPages([name '.Value'], value, isequal(ds, 'loose'));
                 dispAsPages([name '.StdUnc'], unc, isequal(ds, 'loose'));
             else

--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -315,20 +315,8 @@ classdef DistProp
                     value = complex(value);
                     unc = complex(unc);
                 end
-                if isequal(ds, 'compact')
-                    disp([name,'.Value = '])
-                    disp(value)
-                    disp([name,'.StdUnc = '])
-                    disp(unc)
-                else
-                    disp(' ');
-                    disp([name,'.Value = '])
-                    disp(' ');
-                    disp(value)
-                    disp([name,'.StdUnc = '])
-                    disp(' ');
-                    disp(unc)        
-                end
+                dispAsPages([name '.Value'], value, isequal(ds, 'loose'));
+                dispAsPages([name '.StdUnc'], unc, isequal(ds, 'loose'));
             else
                 if isequal(ds, 'compact')
                     fprintf('%s =\n  %s\n', name, char(string(obj)));
@@ -2205,4 +2193,25 @@ classdef DistProp
             obj = DistProp(unc_number);
         end
     end 
+end
+
+function dispAsPages(name, value, isLoose)
+    size_all = size(value);
+    size_residual = size_all(3:end);
+    page_subscripts = cell(1, numel(size_residual));
+    page_name = name;
+    nPages = prod(size_residual);
+    for ii = 1:nPages
+        [page_subscripts{:}] = ind2sub(size_residual,ii);
+
+        if ~isempty(size_residual)
+            page_name = sprintf('%s(:,:,%s)', name, strrep(num2str(cell2mat(page_subscripts)), '  ', ','));
+        end
+
+        if (isLoose && ii==1); disp(' '); end
+        disp([page_name ' = ']);
+        if (isLoose); disp(' '); end
+        disp(value(:, :, page_subscripts{:}));
+        if (isLoose && ii ~= nPages); disp(' '); end
+    end
 end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -299,7 +299,13 @@ classdef LinProp
         function display(obj)
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
-            if obj.IsArray
+            if isempty(obj)
+                if isequal(ds, 'compact')
+                    fprintf('%s =\n     []\n', name);
+                else
+                    fprintf('\n%s =\n\n     []\n\n', name);
+                end
+            elseif obj.IsArray
                 value = get_value(obj);
                 unc = get_stdunc(obj);
                 dispAsPages([name '.Value'], value, isequal(ds, 'loose'));

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -2205,7 +2205,7 @@ function dispAsPages(name, value, isLoose)
         [page_subscripts{:}] = ind2sub(size_residual,ii);
 
         if ~isempty(size_residual)
-            page_name = sprintf('%s(:,:,%s)', name, strrep(num2str(cell2mat(page_subscripts)), '  ', ','));
+            page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
 
         if (isLoose && ii==1); disp(' '); end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -302,10 +302,6 @@ classdef LinProp
             if obj.IsArray
                 value = get_value(obj);
                 unc = get_stdunc(obj);
-                if isreal(value) ~= isreal(unc)
-                    value = complex(value);
-                    unc = complex(unc);
-                end
                 dispAsPages([name '.Value'], value, isequal(ds, 'loose'));
                 dispAsPages([name '.StdUnc'], unc, isequal(ds, 'loose'));
             else

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -315,20 +315,8 @@ classdef LinProp
                     value = complex(value);
                     unc = complex(unc);
                 end
-                if isequal(ds, 'compact')
-                    disp([name,'.Value = '])
-                    disp(value)
-                    disp([name,'.StdUnc = '])
-                    disp(unc)
-                else
-                    disp(' ');
-                    disp([name,'.Value = '])
-                    disp(' ');
-                    disp(value)
-                    disp([name,'.StdUnc = '])
-                    disp(' ');
-                    disp(unc)        
-                end
+                dispAsPages([name '.Value'], value, isequal(ds, 'loose'));
+                dispAsPages([name '.StdUnc'], unc, isequal(ds, 'loose'));
             else
                 if isequal(ds, 'compact')
                     fprintf('%s =\n  %s\n', name, char(string(obj)));
@@ -2205,4 +2193,25 @@ classdef LinProp
             obj = LinProp(unc_number);
         end
     end 
+end
+
+function dispAsPages(name, value, isLoose)
+    size_all = size(value);
+    size_residual = size_all(3:end);
+    page_subscripts = cell(1, numel(size_residual));
+    page_name = name;
+    nPages = prod(size_residual);
+    for ii = 1:nPages
+        [page_subscripts{:}] = ind2sub(size_residual,ii);
+
+        if ~isempty(size_residual)
+            page_name = sprintf('%s(:,:,%s)', name, strrep(num2str(cell2mat(page_subscripts)), '  ', ','));
+        end
+
+        if (isLoose && ii==1); disp(' '); end
+        disp([page_name ' = ']);
+        if (isLoose); disp(' '); end
+        disp(value(:, :, page_subscripts{:}));
+        if (isLoose && ii ~= nPages); disp(' '); end
+    end
 end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -299,7 +299,13 @@ classdef MCProp
         function display(obj)
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
-            if obj.IsArray
+            if isempty(obj)
+                if isequal(ds, 'compact')
+                    fprintf('%s =\n     []\n', name);
+                else
+                    fprintf('\n%s =\n\n     []\n\n', name);
+                end
+            elseif obj.IsArray
                 value = get_value(obj);
                 unc = get_stdunc(obj);
                 dispAsPages([name '.Value'], value, isequal(ds, 'loose'));

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -302,10 +302,6 @@ classdef MCProp
             if obj.IsArray
                 value = get_value(obj);
                 unc = get_stdunc(obj);
-                if isreal(value) ~= isreal(unc)
-                    value = complex(value);
-                    unc = complex(unc);
-                end
                 dispAsPages([name '.Value'], value, isequal(ds, 'loose'));
                 dispAsPages([name '.StdUnc'], unc, isequal(ds, 'loose'));
             else

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -2205,7 +2205,7 @@ function dispAsPages(name, value, isLoose)
         [page_subscripts{:}] = ind2sub(size_residual,ii);
 
         if ~isempty(size_residual)
-            page_name = sprintf('%s(:,:,%s)', name, strrep(num2str(cell2mat(page_subscripts)), '  ', ','));
+            page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
 
         if (isLoose && ii==1); disp(' '); end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -315,20 +315,8 @@ classdef MCProp
                     value = complex(value);
                     unc = complex(unc);
                 end
-                if isequal(ds, 'compact')
-                    disp([name,'.Value = '])
-                    disp(value)
-                    disp([name,'.StdUnc = '])
-                    disp(unc)
-                else
-                    disp(' ');
-                    disp([name,'.Value = '])
-                    disp(' ');
-                    disp(value)
-                    disp([name,'.StdUnc = '])
-                    disp(' ');
-                    disp(unc)        
-                end
+                dispAsPages([name '.Value'], value, isequal(ds, 'loose'));
+                dispAsPages([name '.StdUnc'], unc, isequal(ds, 'loose'));
             else
                 if isequal(ds, 'compact')
                     fprintf('%s =\n  %s\n', name, char(string(obj)));
@@ -2205,4 +2193,25 @@ classdef MCProp
             obj = MCProp(unc_number);
         end
     end 
+end
+
+function dispAsPages(name, value, isLoose)
+    size_all = size(value);
+    size_residual = size_all(3:end);
+    page_subscripts = cell(1, numel(size_residual));
+    page_name = name;
+    nPages = prod(size_residual);
+    for ii = 1:nPages
+        [page_subscripts{:}] = ind2sub(size_residual,ii);
+
+        if ~isempty(size_residual)
+            page_name = sprintf('%s(:,:,%s)', name, strrep(num2str(cell2mat(page_subscripts)), '  ', ','));
+        end
+
+        if (isLoose && ii==1); disp(' '); end
+        disp([page_name ' = ']);
+        if (isLoose); disp(' '); end
+        disp(value(:, :, page_subscripts{:}));
+        if (isLoose && ii ~= nPages); disp(' '); end
+    end
 end


### PR DESCRIPTION
This is the pull-request mentioned in https://github.com/wollmich/metas-unclib-matlab-wrapper/pull/58#issuecomment-1129784566.

I made the function `dispAsPages()` local to the file, so it could in the future be used by other methods, e.g. in #46. However, the function could also be made local to the `display()` function, i.e. defined inside it.