### PR TITLE
Proposed fix for issue #62. Reverting now obsolete check in display().

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -309,25 +309,19 @@ classdef DistProp
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
-                value = get_value(obj);
-                unc = get_stdunc(obj);
-                if isreal(value) ~= isreal(unc)
-                    value = complex(value);
-                    unc = complex(unc);
-                end
                 if isequal(ds, 'compact')
                     disp([name,'.Value = '])
-                    disp(value)
+                    disp(get_value(obj))
                     disp([name,'.StdUnc = '])
-                    disp(unc)
+                    disp(get_stdunc(obj))
                 else
                     disp(' ');
                     disp([name,'.Value = '])
                     disp(' ');
-                    disp(value)
+                    disp(get_value(obj))
                     disp([name,'.StdUnc = '])
                     disp(' ');
-                    disp(unc)        
+                    disp(get_stdunc(obj))        
                 end
             else
                 if isequal(ds, 'compact')
@@ -2054,14 +2048,14 @@ classdef DistProp
             if DistProp.IsArrayNet(x)
                 s = int32(x.size);
                 if DistProp.IsComplexNet(x)
-                    d = double(x.DblRealValue()) + 1i.*double(x.DblImagValue());
+                    d = complex(double(x.DblRealValue()), double(x.DblImagValue()));
                 else
                     d = double(x.DblValue());
                 end
                 d = reshape(d, s);
             else
                 if DistProp.IsComplexNet(x)
-                    d = x.DblRealValue() + 1i*x.DblImagValue();
+                    d = complex(x.DblRealValue(), x.DblImagValue());
                 else
                     d = x.Value;
                 end

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -309,25 +309,19 @@ classdef LinProp
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
-                value = get_value(obj);
-                unc = get_stdunc(obj);
-                if isreal(value) ~= isreal(unc)
-                    value = complex(value);
-                    unc = complex(unc);
-                end
                 if isequal(ds, 'compact')
                     disp([name,'.Value = '])
-                    disp(value)
+                    disp(get_value(obj))
                     disp([name,'.StdUnc = '])
-                    disp(unc)
+                    disp(get_stdunc(obj))
                 else
                     disp(' ');
                     disp([name,'.Value = '])
                     disp(' ');
-                    disp(value)
+                    disp(get_value(obj))
                     disp([name,'.StdUnc = '])
                     disp(' ');
-                    disp(unc)        
+                    disp(get_stdunc(obj))        
                 end
             else
                 if isequal(ds, 'compact')
@@ -2054,14 +2048,14 @@ classdef LinProp
             if LinProp.IsArrayNet(x)
                 s = int32(x.size);
                 if LinProp.IsComplexNet(x)
-                    d = double(x.DblRealValue()) + 1i.*double(x.DblImagValue());
+                    d = complex(double(x.DblRealValue()), double(x.DblImagValue()));
                 else
                     d = double(x.DblValue());
                 end
                 d = reshape(d, s);
             else
                 if LinProp.IsComplexNet(x)
-                    d = x.DblRealValue() + 1i*x.DblImagValue();
+                    d = complex(x.DblRealValue(), x.DblImagValue());
                 else
                     d = x.Value;
                 end

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -309,25 +309,19 @@ classdef MCProp
             name = inputname(1);
             ds = get(0, 'FormatSpacing');
             if obj.IsArray
-                value = get_value(obj);
-                unc = get_stdunc(obj);
-                if isreal(value) ~= isreal(unc)
-                    value = complex(value);
-                    unc = complex(unc);
-                end
                 if isequal(ds, 'compact')
                     disp([name,'.Value = '])
-                    disp(value)
+                    disp(get_value(obj))
                     disp([name,'.StdUnc = '])
-                    disp(unc)
+                    disp(get_stdunc(obj))
                 else
                     disp(' ');
                     disp([name,'.Value = '])
                     disp(' ');
-                    disp(value)
+                    disp(get_value(obj))
                     disp([name,'.StdUnc = '])
                     disp(' ');
-                    disp(unc)        
+                    disp(get_stdunc(obj))        
                 end
             else
                 if isequal(ds, 'compact')
@@ -2054,14 +2048,14 @@ classdef MCProp
             if MCProp.IsArrayNet(x)
                 s = int32(x.size);
                 if MCProp.IsComplexNet(x)
-                    d = double(x.DblRealValue()) + 1i.*double(x.DblImagValue());
+                    d = complex(double(x.DblRealValue()), double(x.DblImagValue()));
                 else
                     d = double(x.DblValue());
                 end
                 d = reshape(d, s);
             else
                 if MCProp.IsComplexNet(x)
-                    d = x.DblRealValue() + 1i*x.DblImagValue();
+                    d = complex(x.DblRealValue(), x.DblImagValue());
                 else
                     d = x.Value;
                 end


### PR DESCRIPTION
This is my proposed solution for #62.

The `complex()` function is [intended for creating complex numbers when the imag part may be zero](https://de.mathworks.com/help/matlab/ref/complex.html#d123e218554), thus it should be used in `Convert2Double()`.
```MATLAB
                if LinProp.IsComplexNet(x)
                    d = complex(double(x.DblRealValue()), double(x.DblImagValue()));
                else
```

However, `Convert2Double()` is also used in many other functions, such as `get_correlation()`, `get_idof()`, etc. Thus, there could be unwanted side-effects. 

`get_correlation()` works fine as the data passed to `LinProp.Convert2Double()` inside it is always real-valued. But I am for example unsure how `get_idof()` is used and what it is supposed to return and therefore am unsure if there are unwanted side-effects. 