### PR TITLE
Added isreal() method.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.DistProp V2.5.4
 % Michael Wollensack METAS - 10.05.2022
-% Dion Timmermann PTB - 19.05.2022
+% Dion Timmermann PTB - 01.06.2022
 %
 % DistProp Const:
 % a = DistProp(value)
@@ -1430,6 +1430,9 @@ classdef DistProp
         end
         function y = isnan(x)
             y = isnan(double(x));
+        end
+        function y = isreal(x)
+            y = ~x.IsComplex;
         end
         function y = transpose(x)
             if x.IsArray

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.LinProp V2.5.4
 % Michael Wollensack METAS - 10.05.2022
-% Dion Timmermann PTB - 19.05.2022
+% Dion Timmermann PTB - 01.06.2022
 %
 % LinProp Const:
 % a = LinProp(value)
@@ -1430,6 +1430,9 @@ classdef LinProp
         end
         function y = isnan(x)
             y = isnan(double(x));
+        end
+        function y = isreal(x)
+            y = ~x.IsComplex;
         end
         function y = transpose(x)
             if x.IsArray

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,6 +1,6 @@
 % Metas.UncLib.Matlab.MCProp V2.5.4
 % Michael Wollensack METAS - 10.05.2022
-% Dion Timmermann PTB - 19.05.2022
+% Dion Timmermann PTB - 01.06.2022
 %
 % MCProp Const:
 % a = MCProp(value)
@@ -1430,6 +1430,9 @@ classdef MCProp
         end
         function y = isnan(x)
             y = isnan(double(x));
+        end
+        function y = isreal(x)
+            y = ~x.IsComplex;
         end
         function y = transpose(x)
             if x.IsArray


### PR DESCRIPTION
Adds the `isreal()` method that is used to test if a variable contains complex values. 

This method is required for compatibility. Specifically, this change allows comparing *Prop quantities with tolerances using verifyEqual in unit tests. With the changes in this pull-request the follwing unit test works:

```MATLAB
classdef LinPropTest < matlab.unittest.TestCase
    
    methods (Test)
        
        function example(testCase)
            a = LinProp(1);
            b = LinProp(1-eps);
            
            verifyEqual(testCase, a, b, 'AbsTol', LinProp(0.1));
        end
        
    end
    
end
```