### PR TITLE
Added support for Real<UncNumber>

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -1,5 +1,5 @@
-% Metas.UncLib.Matlab.DistProp V2.5.4
-% Michael Wollensack METAS - 10.05.2022
+% Metas.UncLib.Matlab.DistProp V2.5.5
+% Michael Wollensack METAS - 05.07.2022
 % Dion Timmermann PTB - 22.06.2022
 %
 % DistProp Const:
@@ -80,6 +80,8 @@ classdef DistProp
                             end
                         case 'Metas.UncLib.DistProp.UncNumber'
                             obj.NetObject = varargin{1};
+                        case 'Metas.UncLib.Core.Real<Metas*UncLib*DistProp*UncNumber>'
+                            obj.NetObject = varargin{1}.Item;
                         case 'Metas.UncLib.Core.Complex<Metas*UncLib*DistProp*UncNumber>'
                             obj.NetObject = varargin{1};
                         case 'Metas.UncLib.Core.Ndims.RealNArray<Metas*UncLib*DistProp*UncNumber>'

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -1,5 +1,5 @@
-% Metas.UncLib.Matlab.LinProp V2.5.4
-% Michael Wollensack METAS - 10.05.2022
+% Metas.UncLib.Matlab.LinProp V2.5.5
+% Michael Wollensack METAS - 05.07.2022
 % Dion Timmermann PTB - 22.06.2022
 %
 % LinProp Const:
@@ -80,6 +80,8 @@ classdef LinProp
                             end
                         case 'Metas.UncLib.LinProp.UncNumber'
                             obj.NetObject = varargin{1};
+                        case 'Metas.UncLib.Core.Real<Metas*UncLib*LinProp*UncNumber>'
+                            obj.NetObject = varargin{1}.Item;
                         case 'Metas.UncLib.Core.Complex<Metas*UncLib*LinProp*UncNumber>'
                             obj.NetObject = varargin{1};
                         case 'Metas.UncLib.Core.Ndims.RealNArray<Metas*UncLib*LinProp*UncNumber>'

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -1,5 +1,5 @@
-% Metas.UncLib.Matlab.MCProp V2.5.4
-% Michael Wollensack METAS - 10.05.2022
+% Metas.UncLib.Matlab.MCProp V2.5.5
+% Michael Wollensack METAS - 05.07.2022
 % Dion Timmermann PTB - 22.06.2022
 %
 % MCProp Const:
@@ -80,6 +80,8 @@ classdef MCProp
                             end
                         case 'Metas.UncLib.MCProp.UncNumber'
                             obj.NetObject = varargin{1};
+                        case 'Metas.UncLib.Core.Real<Metas*UncLib*MCProp*UncNumber>'
+                            obj.NetObject = varargin{1}.Item;
                         case 'Metas.UncLib.Core.Complex<Metas*UncLib*MCProp*UncNumber>'
                             obj.NetObject = varargin{1};
                         case 'Metas.UncLib.Core.Ndims.RealNArray<Metas*UncLib*MCProp*UncNumber>'


### PR DESCRIPTION
C#: Real<T> generic struct added to capsule an IRealNumber<T> because interfaces do not support operator overloading and implicit type conversion.