### PR TITLE
Added read-only properties Const2014, Const2014_90, Const2018 and Const for physical constants.

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -2243,9 +2243,13 @@ classdef DistProp
         end
     end
     properties (Constant)
+        % Physical Constants CODATA 2014
         Const2014 = InitConst2014();
+        % Physical Constants CODATA 2014 for Conventional Electrical Units 90
         Const2014_90 = InitConst2014_90();
+        % Physical Constants CODATA 2018
         Const2018 = InitConst2018();
+        % Newest Physical Constants
         Const = InitConst2018();
     end
 end
@@ -2254,27 +2258,49 @@ function c = InitConst2014()
     const = Metas.UncLib.Core.Const2014;
     uconst =  NET.createGeneric('Metas.UncLib.Core.Const2014', {'Metas.UncLib.DistProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = const.mu0;
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = const.ep0;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Molar mass constant / (kg/mol)
     c.Mu = const.Mu;
+    % Newtonian constant of gravitation / (m^3/(kg*s^2))
     c.G = DistProp(uconst.G);
+    % Fine-structure constant
     c.alpha = DistProp(uconst.alpha);
+    % Rydberg constant / (1/m)
     c.Ryd = DistProp(uconst.Ryd);
+    % Proton-electron mass ratio
     c.mpsme = DistProp(uconst.mpsme);
+    % Avogadro constant / (1/mol)
     c.Na = DistProp(uconst.Na);
+    % Josephson constant / (Hz/V)
     c.Kj = DistProp(uconst.Kj);
+    % Boltzmann constant / (J/K)
     c.k = DistProp(uconst.k);
+    % von Klitzing constant / Ohm
     c.Rk = DistProp(uconst.Rk);
+    % Elementary charge / C
     c.e = DistProp(uconst.e);
+    % Planck constant / Js
     c.h = DistProp(uconst.h);
+    % Electron mass / kg
     c.me = DistProp(uconst.me);
+    % Proton mass / kg
     c.mp = DistProp(uconst.mp);
+    % Atomic mass constant / kg
     c.u = DistProp(uconst.u);
+    % Faraday constant / (C/mol)
     c.F = DistProp(uconst.F);
+    % Molar gas constant / (J/(mol*K))
     c.R = DistProp(uconst.R);
+    % Electron volt / J
     c.eV = DistProp(uconst.eV);
 end
 
@@ -2283,18 +2309,31 @@ function c = InitConst2014_90()
     const90 = Metas.UncLib.Core.Const2014_90;
     uconst90 =  NET.createGeneric('Metas.UncLib.Core.Const2014_90', {'Metas.UncLib.DistProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = const.mu0;
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = const.ep0;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Molar mass constant / (kg/mol)
     c.Mu = const.Mu;
+    % Conventional value of Josephson constant / (Hz/V)
     c.Kj = const90.Kj;
+    % Conventional value of von Klitzing constant / Ohm
     c.Rk = const90.Rk;
+    % Elementary charge / C
     c.e = const90.e;
+    % Planck constant / Js
     c.h = const90.h;
+    % Avogadro constant / (1/mol)
     c.Na = DistProp(uconst90.Na);
+    % Faraday constant / (C/mol)
     c.F = DistProp(uconst90.F);
+    % Boltzmann constant / (J/K)
     c.k = DistProp(uconst90.k);
 end
 
@@ -2302,29 +2341,53 @@ function c = InitConst2018()
     const = Metas.UncLib.Core.Const2018;
     uconst =  NET.createGeneric('Metas.UncLib.Core.Const2018', {'Metas.UncLib.DistProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Planck constant / Js
     c.h = const.h;
+    % Elementary charge / C
     c.e = const.e;
+    % Boltzmann constant / (J/K)
     c.k = const.k;
+    % Avogadro constant / (1/mol)
     c.Na = const.Na;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Josephson constant / (Hz/V)
     c.Kj = const.Kj;
+    % von Klitzing constant / Ohm
     c.Rk = const.Rk;
+    % Faraday constant / (C/mol)
     c.F = const.F;
+    % Molar gas constant / (J/(mol*K))
     c.R = const.R;
+    % Electron volt / J
     c.eV = const.eV;
+    % Newtonian constant of gravitation / (m^3/(kg*s^2))
     c.G = DistProp(uconst.G);
+    % Fine-structure constant
     c.alpha = DistProp(uconst.alpha);
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = DistProp(uconst.mu0);
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = DistProp(uconst.ep0);
+    % Rydberg constant / (1/m)
     c.Ryd = DistProp(uconst.Ryd);
+    % Electron mass / kg
     c.me = DistProp(uconst.me);
+    % Electron relative atomic mass
     c.are = DistProp(uconst.are);
+    % Proton relative atomic mass
     c.arp = DistProp(uconst.arp);
+    % Proton-electron mass ratio
     c.mpsme = DistProp(uconst.mpsme);
+    % Proton mass / kg
     c.mp = DistProp(uconst.mp);
+    % Atomic mass constant / kg
     c.u = DistProp(uconst.u);
+    % Molar mass constant / (kg/mol)
     c.Mu = DistProp(uconst.Mu);
 end
 

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -2243,9 +2243,13 @@ classdef LinProp
         end
     end
     properties (Constant)
+        % Physical Constants CODATA 2014
         Const2014 = InitConst2014();
+        % Physical Constants CODATA 2014 for Conventional Electrical Units 90
         Const2014_90 = InitConst2014_90();
+        % Physical Constants CODATA 2018
         Const2018 = InitConst2018();
+        % Newest Physical Constants
         Const = InitConst2018();
     end
 end
@@ -2254,27 +2258,49 @@ function c = InitConst2014()
     const = Metas.UncLib.Core.Const2014;
     uconst =  NET.createGeneric('Metas.UncLib.Core.Const2014', {'Metas.UncLib.LinProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = const.mu0;
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = const.ep0;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Molar mass constant / (kg/mol)
     c.Mu = const.Mu;
+    % Newtonian constant of gravitation / (m^3/(kg*s^2))
     c.G = LinProp(uconst.G);
+    % Fine-structure constant
     c.alpha = LinProp(uconst.alpha);
+    % Rydberg constant / (1/m)
     c.Ryd = LinProp(uconst.Ryd);
+    % Proton-electron mass ratio
     c.mpsme = LinProp(uconst.mpsme);
+    % Avogadro constant / (1/mol)
     c.Na = LinProp(uconst.Na);
+    % Josephson constant / (Hz/V)
     c.Kj = LinProp(uconst.Kj);
+    % Boltzmann constant / (J/K)
     c.k = LinProp(uconst.k);
+    % von Klitzing constant / Ohm
     c.Rk = LinProp(uconst.Rk);
+    % Elementary charge / C
     c.e = LinProp(uconst.e);
+    % Planck constant / Js
     c.h = LinProp(uconst.h);
+    % Electron mass / kg
     c.me = LinProp(uconst.me);
+    % Proton mass / kg
     c.mp = LinProp(uconst.mp);
+    % Atomic mass constant / kg
     c.u = LinProp(uconst.u);
+    % Faraday constant / (C/mol)
     c.F = LinProp(uconst.F);
+    % Molar gas constant / (J/(mol*K))
     c.R = LinProp(uconst.R);
+    % Electron volt / J
     c.eV = LinProp(uconst.eV);
 end
 
@@ -2283,18 +2309,31 @@ function c = InitConst2014_90()
     const90 = Metas.UncLib.Core.Const2014_90;
     uconst90 =  NET.createGeneric('Metas.UncLib.Core.Const2014_90', {'Metas.UncLib.LinProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = const.mu0;
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = const.ep0;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Molar mass constant / (kg/mol)
     c.Mu = const.Mu;
+    % Conventional value of Josephson constant / (Hz/V)
     c.Kj = const90.Kj;
+    % Conventional value of von Klitzing constant / Ohm
     c.Rk = const90.Rk;
+    % Elementary charge / C
     c.e = const90.e;
+    % Planck constant / Js
     c.h = const90.h;
+    % Avogadro constant / (1/mol)
     c.Na = LinProp(uconst90.Na);
+    % Faraday constant / (C/mol)
     c.F = LinProp(uconst90.F);
+    % Boltzmann constant / (J/K)
     c.k = LinProp(uconst90.k);
 end
 
@@ -2302,29 +2341,53 @@ function c = InitConst2018()
     const = Metas.UncLib.Core.Const2018;
     uconst =  NET.createGeneric('Metas.UncLib.Core.Const2018', {'Metas.UncLib.LinProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Planck constant / Js
     c.h = const.h;
+    % Elementary charge / C
     c.e = const.e;
+    % Boltzmann constant / (J/K)
     c.k = const.k;
+    % Avogadro constant / (1/mol)
     c.Na = const.Na;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Josephson constant / (Hz/V)
     c.Kj = const.Kj;
+    % von Klitzing constant / Ohm
     c.Rk = const.Rk;
+    % Faraday constant / (C/mol)
     c.F = const.F;
+    % Molar gas constant / (J/(mol*K))
     c.R = const.R;
+    % Electron volt / J
     c.eV = const.eV;
+    % Newtonian constant of gravitation / (m^3/(kg*s^2))
     c.G = LinProp(uconst.G);
+    % Fine-structure constant
     c.alpha = LinProp(uconst.alpha);
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = LinProp(uconst.mu0);
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = LinProp(uconst.ep0);
+    % Rydberg constant / (1/m)
     c.Ryd = LinProp(uconst.Ryd);
+    % Electron mass / kg
     c.me = LinProp(uconst.me);
+    % Electron relative atomic mass
     c.are = LinProp(uconst.are);
+    % Proton relative atomic mass
     c.arp = LinProp(uconst.arp);
+    % Proton-electron mass ratio
     c.mpsme = LinProp(uconst.mpsme);
+    % Proton mass / kg
     c.mp = LinProp(uconst.mp);
+    % Atomic mass constant / kg
     c.u = LinProp(uconst.u);
+    % Molar mass constant / (kg/mol)
     c.Mu = LinProp(uconst.Mu);
 end
 

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -2243,9 +2243,13 @@ classdef MCProp
         end
     end
     properties (Constant)
+        % Physical Constants CODATA 2014
         Const2014 = InitConst2014();
+        % Physical Constants CODATA 2014 for Conventional Electrical Units 90
         Const2014_90 = InitConst2014_90();
+        % Physical Constants CODATA 2018
         Const2018 = InitConst2018();
+        % Newest Physical Constants
         Const = InitConst2018();
     end
 end
@@ -2254,27 +2258,49 @@ function c = InitConst2014()
     const = Metas.UncLib.Core.Const2014;
     uconst =  NET.createGeneric('Metas.UncLib.Core.Const2014', {'Metas.UncLib.MCProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = const.mu0;
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = const.ep0;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Molar mass constant / (kg/mol)
     c.Mu = const.Mu;
+    % Newtonian constant of gravitation / (m^3/(kg*s^2))
     c.G = MCProp(uconst.G);
+    % Fine-structure constant
     c.alpha = MCProp(uconst.alpha);
+    % Rydberg constant / (1/m)
     c.Ryd = MCProp(uconst.Ryd);
+    % Proton-electron mass ratio
     c.mpsme = MCProp(uconst.mpsme);
+    % Avogadro constant / (1/mol)
     c.Na = MCProp(uconst.Na);
+    % Josephson constant / (Hz/V)
     c.Kj = MCProp(uconst.Kj);
+    % Boltzmann constant / (J/K)
     c.k = MCProp(uconst.k);
+    % von Klitzing constant / Ohm
     c.Rk = MCProp(uconst.Rk);
+    % Elementary charge / C
     c.e = MCProp(uconst.e);
+    % Planck constant / Js
     c.h = MCProp(uconst.h);
+    % Electron mass / kg
     c.me = MCProp(uconst.me);
+    % Proton mass / kg
     c.mp = MCProp(uconst.mp);
+    % Atomic mass constant / kg
     c.u = MCProp(uconst.u);
+    % Faraday constant / (C/mol)
     c.F = MCProp(uconst.F);
+    % Molar gas constant / (J/(mol*K))
     c.R = MCProp(uconst.R);
+    % Electron volt / J
     c.eV = MCProp(uconst.eV);
 end
 
@@ -2283,18 +2309,31 @@ function c = InitConst2014_90()
     const90 = Metas.UncLib.Core.Const2014_90;
     uconst90 =  NET.createGeneric('Metas.UncLib.Core.Const2014_90', {'Metas.UncLib.MCProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = const.mu0;
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = const.ep0;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Molar mass constant / (kg/mol)
     c.Mu = const.Mu;
+    % Conventional value of Josephson constant / (Hz/V)
     c.Kj = const90.Kj;
+    % Conventional value of von Klitzing constant / Ohm
     c.Rk = const90.Rk;
+    % Elementary charge / C
     c.e = const90.e;
+    % Planck constant / Js
     c.h = const90.h;
+    % Avogadro constant / (1/mol)
     c.Na = MCProp(uconst90.Na);
+    % Faraday constant / (C/mol)
     c.F = MCProp(uconst90.F);
+    % Boltzmann constant / (J/K)
     c.k = MCProp(uconst90.k);
 end
 
@@ -2302,29 +2341,53 @@ function c = InitConst2018()
     const = Metas.UncLib.Core.Const2018;
     uconst =  NET.createGeneric('Metas.UncLib.Core.Const2018', {'Metas.UncLib.MCProp.UncNumber'});
     c = {};
+    % Hyperfine transition frequency of Cs-133 / Hz
     c.deltavCs = const.deltavCs;
+    % Speed of light in vacuum / (m/s)
     c.c0 = const.c0;
+    % Planck constant / Js
     c.h = const.h;
+    % Elementary charge / C
     c.e = const.e;
+    % Boltzmann constant / (J/K)
     c.k = const.k;
+    % Avogadro constant / (1/mol)
     c.Na = const.Na;
+    % Luminous efficacy / (lm/W)
     c.Kcd = const.Kcd;
+    % Josephson constant / (Hz/V)
     c.Kj = const.Kj;
+    % von Klitzing constant / Ohm
     c.Rk = const.Rk;
+    % Faraday constant / (C/mol)
     c.F = const.F;
+    % Molar gas constant / (J/(mol*K))
     c.R = const.R;
+    % Electron volt / J
     c.eV = const.eV;
+    % Newtonian constant of gravitation / (m^3/(kg*s^2))
     c.G = MCProp(uconst.G);
+    % Fine-structure constant
     c.alpha = MCProp(uconst.alpha);
+    % Vacuum magnetic permeability / (Vs/Am)
     c.mu0 = MCProp(uconst.mu0);
+    % Vacuum electric permittivity / (As/Vm)
     c.ep0 = MCProp(uconst.ep0);
+    % Rydberg constant / (1/m)
     c.Ryd = MCProp(uconst.Ryd);
+    % Electron mass / kg
     c.me = MCProp(uconst.me);
+    % Electron relative atomic mass
     c.are = MCProp(uconst.are);
+    % Proton relative atomic mass
     c.arp = MCProp(uconst.arp);
+    % Proton-electron mass ratio
     c.mpsme = MCProp(uconst.mpsme);
+    % Proton mass / kg
     c.mp = MCProp(uconst.mp);
+    % Atomic mass constant / kg
     c.u = MCProp(uconst.u);
+    % Molar mass constant / (kg/mol)
     c.Mu = MCProp(uconst.Mu);
 end
 


### PR DESCRIPTION
Physical constants (CODATA 2014, 2014 90 and 2018) have been added to METAS UncLib. They have been wrapped to MATLAB.

### CODATA 2014

```
>> LinProp.Const2014

ans = 

  struct with fields:

    deltavCs: 9.192631770000000e+09
          c0: 299792458
         mu0: 1.256637061435917e-06
         ep0: 8.854187817620389e-12
         Kcd: 683
          Mu: 1.000000000000000e-03
           G: [1×1 LinProp]
       alpha: [1×1 LinProp]
         Ryd: [1×1 LinProp]
       mpsme: [1×1 LinProp]
          Na: [1×1 LinProp]
          Kj: [1×1 LinProp]
           k: [1×1 LinProp]
          Rk: [1×1 LinProp]
           e: [1×1 LinProp]
           h: [1×1 LinProp]
          me: [1×1 LinProp]
          mp: [1×1 LinProp]
           u: [1×1 LinProp]
           F: [1×1 LinProp]
           R: [1×1 LinProp]
          eV: [1×1 LinProp]
```

### CODATA 2014 for Conventional Electrical Units 90

```
>> LinProp.Const2014_90

ans = 

  struct with fields:

    deltavCs: 9.192631770000000e+09
          c0: 299792458
         mu0: 1.256637061435917e-06
         ep0: 8.854187817620389e-12
         Kcd: 683
          Mu: 1.000000000000000e-03
          Kj: 4.835979000000000e+14
          Rk: 2.581280700000000e+04
           e: 1.602176491612271e-19
           h: 6.626068854361324e-34
          Na: [1×1 LinProp]
           F: [1×1 LinProp]
           k: [1×1 LinProp]
```

###  CODATA 2018

```
>> LinProp.Const2018

ans = 

  struct with fields:

    deltavCs: 9.192631770000000e+09
          c0: 299792458
           h: 6.626070150000000e-34
           e: 1.602176634000000e-19
           k: 1.380649000000000e-23
          Na: 6.022140760000000e+23
         Kcd: 683
          Kj: 4.835978484169836e+14
          Rk: 2.581280745930451e+04
           F: 9.648533212331001e+04
           R: 8.314462618153240
          eV: 1.602176634000000e-19
           G: [1×1 LinProp]
       alpha: [1×1 LinProp]
         mu0: [1×1 LinProp]
         ep0: [1×1 LinProp]
         Ryd: [1×1 LinProp]
          me: [1×1 LinProp]
         are: [1×1 LinProp]
         arp: [1×1 LinProp]
       mpsme: [1×1 LinProp]
          mp: [1×1 LinProp]
           u: [1×1 LinProp]
          Mu: [1×1 LinProp]
```

`LinProp.Const` will return the newest physical constants.  Up to now that's `LinProp.Const2018`.