### PR TITLE
Convert LinProp2MCProp to an object converter method

### DIFF
--- a/@LinProp/MCProp.m
+++ b/@LinProp/MCProp.m
@@ -1,11 +1,11 @@
-function xMC = LinProp2MCProp(x)
-% LinProp2MCProp Converts LinProp objects to MCProp objects
+function xMC = MCProp(x)
+% Converts objects to MCProp
 %
-%   xMC = LinProp2MCProp(x) returns MCProp objects where
+%   xMC = MCProp(x) returns MCProp objects where
 %     x are the input LinProp objects.
 %
 %   Example of usage:
-%     xMC = LinProp2MCProp(x);
+%     xMC = MCProp(x);
 %     yMC = f(xMC);
 %     y = MCProp2LinProp(yMC, xMC, x);
 %


### PR DESCRIPTION
If you intentionally did not use this approach, feel free to deny this pull-request.

I changed LinProp2MCProp to a method of LinProp called MCProp. This is "the matlab way" for object conversion. Matlab will search for this method if it needs to convert a LinProp to an MCProp, as e.g. in the following example:
```MATLAB
l = LinProp(1, 0.1);
m = MCProp(2, 0.2);
c = [m, l]
```

see https://de.mathworks.com/help/matlab/matlab_oop/concatenating-objects-of-different-classes.html#buoea3n-1.

The backwards conversion does not work as nicely, as MCProp2LinProp requires more than one argument.

Note that you will need to restart matlab after merging/switching branches.