### PR TITLE
Fix for Matlab 2024b: add default values for array size of scalars when missing

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -2755,6 +2755,7 @@ end
 function dispAsPages(name, value, isLoose)
     size_all = size(value);
     size_residual = size_all(3:end);
+    size_residual = [size_residual ones(1, max(0, 2-length(size_residual)))];
     page_subscripts = cell(1, numel(size_residual));
     page_name = name;
     nPages = prod(size_residual);
@@ -2768,7 +2769,7 @@ function dispAsPages(name, value, isLoose)
             page_values = complex(page_values);
         end
 
-        if ~isempty(size_residual)
+        if ~isempty(size_all(3:end))
             page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
         

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -2755,6 +2755,7 @@ end
 function dispAsPages(name, value, isLoose)
     size_all = size(value);
     size_residual = size_all(3:end);
+    size_residual = [size_residual ones(1, max(0, 2-length(size_residual)))];
     page_subscripts = cell(1, numel(size_residual));
     page_name = name;
     nPages = prod(size_residual);
@@ -2768,7 +2769,7 @@ function dispAsPages(name, value, isLoose)
             page_values = complex(page_values);
         end
 
-        if ~isempty(size_residual)
+        if ~isempty(size_all(3:end))
             page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
         

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -2755,6 +2755,7 @@ end
 function dispAsPages(name, value, isLoose)
     size_all = size(value);
     size_residual = size_all(3:end);
+    size_residual = [size_residual ones(1, max(0, 2-length(size_residual)))];
     page_subscripts = cell(1, numel(size_residual));
     page_name = name;
     nPages = prod(size_residual);
@@ -2768,7 +2769,7 @@ function dispAsPages(name, value, isLoose)
             page_values = complex(page_values);
         end
 
-        if ~isempty(size_residual)
+        if ~isempty(size_all(3:end))
             page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
         


### PR DESCRIPTION
In Matlab2024b the used matlab function 'ind2sub' has changed behavior.

Matlab doc of “ind2sub”: R2024b: Scalar input for array size is not supported. Starting in R2024b, a scalar input for sz results in an error. Instead, you must specify sz as a vector of positive integers with two or more elements.

That means that in previous Matlab versions missing parameter values were set to default values (scalar as array of size(1, 1).

In Matlab2024b the array size has to be set explicitely to [1 1]  for scalar values.