### PR TITLE
add missing default values required in Matlab 2024b

### DIFF
--- a/@DistProp/DistProp.m
+++ b/@DistProp/DistProp.m
@@ -2755,6 +2755,7 @@ end
 function dispAsPages(name, value, isLoose)
     size_all = size(value);
     size_residual = size_all(3:end);
+    size_residual = [size_residual ones(1, max(0, 2-length(size_residual)))];
     page_subscripts = cell(1, numel(size_residual));
     page_name = name;
     nPages = prod(size_residual);
@@ -2768,7 +2769,7 @@ function dispAsPages(name, value, isLoose)
             page_values = complex(page_values);
         end
 
-        if ~isempty(size_residual)
+        if ~isempty(size_all(3:end))
             page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
         

--- a/@LinProp/LinProp.m
+++ b/@LinProp/LinProp.m
@@ -2755,6 +2755,7 @@ end
 function dispAsPages(name, value, isLoose)
     size_all = size(value);
     size_residual = size_all(3:end);
+    size_residual = [size_residual ones(1, max(0, 2-length(size_residual)))];
     page_subscripts = cell(1, numel(size_residual));
     page_name = name;
     nPages = prod(size_residual);
@@ -2768,7 +2769,7 @@ function dispAsPages(name, value, isLoose)
             page_values = complex(page_values);
         end
 
-        if ~isempty(size_residual)
+        if ~isempty(size_all(3:end))
             page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
         

--- a/@MCProp/MCProp.m
+++ b/@MCProp/MCProp.m
@@ -2755,6 +2755,7 @@ end
 function dispAsPages(name, value, isLoose)
     size_all = size(value);
     size_residual = size_all(3:end);
+    size_residual = [size_residual ones(1, max(0, 2-length(size_residual)))];
     page_subscripts = cell(1, numel(size_residual));
     page_name = name;
     nPages = prod(size_residual);
@@ -2768,7 +2769,7 @@ function dispAsPages(name, value, isLoose)
             page_values = complex(page_values);
         end
 
-        if ~isempty(size_residual)
+        if ~isempty(size_all(3:end))
             page_name = sprintf('%s(:,:,%s)', name, strjoin(strsplit(num2str(cell2mat(page_subscripts))), ','));
         end
         


### PR DESCRIPTION
function 'ind2sub' in Matlab2024b requires array size even for scalar values
in previous versions this parameter can be missing and is assumed as array size [1 1]
from Matlab2024b the array size has to be specified